### PR TITLE
ci: add workflow to sync develop from main after release

### DIFF
--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -1,0 +1,29 @@
+name: Sync develop from main
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    name: Merge main into develop
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Merge main into develop
+        run: |
+          git merge origin/main --no-edit
+          git push origin develop


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/sync-develop.yml` that triggers on any push to `main`
- Automatically merges `main` back into `develop` so the branches stay in sync after every release
- Uses `github-actions[bot]` as the git author for the merge commit

## How it works

1. Triggered by `push` to `main` (i.e. after a release PR is merged)
2. Checks out `develop` with full history
3. Merges `origin/main` into `develop` with `--no-edit`
4. Pushes the result back to `origin/develop`

This prevents the "branch is out of date" situation on future release PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)