### PR TITLE
ci: auto-assign issues and PRs to the opener

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,26 @@
+name: Auto Assign
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  assign:
+    name: Assign to opener
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: [context.payload.sender.login],
+            });


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/auto-assign.yml` that fires on `issues.opened` and `pull_request.opened`
- Assigns the person who opened the issue or PR to themselves automatically

## How it works

Uses `actions/github-script` to call the GitHub API and add `context.payload.sender.login` as an assignee. Works for both issues and PRs since GitHub treats PR assignees via the issues API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)