### PR TITLE
release: add CI automation workflows

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,26 @@
+name: Auto Assign
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  assign:
+    name: Assign to opener
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: [context.payload.sender.login],
+            });


### PR DESCRIPTION
## Release Summary

This release includes two CI automation improvements added after the previous release.

### Changes

- **ci: auto-assign issues and PRs to the opener** (#9)
  - Adds `.github/workflows/auto-assign.yml` — automatically assigns the creator of any issue or PR to themselves on open

- **ci: sync develop from main after release** (#8)
  - Adds `.github/workflows/sync-develop.yml` — automatically merges `main` back into `develop` after every push to `main`, keeping branches in sync

## Test plan

- [ ] Open a new issue and confirm it is auto-assigned
- [ ] Open a new PR and confirm it is auto-assigned
- [ ] Merge a future release PR and confirm `develop` is automatically synced from `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)