### PR TITLE
docs: update README and add SETUP guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,97 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Eorzea Estates
+
+A community directory for Final Fantasy XIV player housing estates. Browse, submit, and discover decorated homes across all worlds.
+
+## Features
+
+- Browse the estate directory with search and filtering
+- Submit your own estate with screenshots and details
+- Estate detail pages with images and community engagement
+- User profiles listing submitted estates
+- Discord OAuth login via Auth.js
+- Admin dashboard with estate verification workflow
+
+## Tech Stack
+
+| Layer | Technology |
+|---|---|
+| Framework | Next.js 16 (App Router) |
+| Language | TypeScript |
+| Auth | Auth.js v5 (Discord OAuth) |
+| Database | PostgreSQL via Supabase |
+| ORM | Prisma |
+| Image Hosting | Cloudinary |
+| UI | Tailwind CSS v4, shadcn/ui, Radix UI |
+| Forms | React Hook Form + Zod |
+| Testing | Vitest (unit), Playwright (E2E) |
+| CI/CD | GitHub Actions, semantic-release |
 
 ## Getting Started
 
-First, run the development server:
+### Prerequisites
+
+- Node.js 22+
+- [pnpm](https://pnpm.io/installation)
+
+### Environment Setup
+
+Follow [SETUP.md](SETUP.md) to configure Supabase, Discord OAuth, and Cloudinary, then create your `.env` file.
+
+### Install & Run
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
+pnpm install
+pnpm prisma migrate dev --name init
 pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000).
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Scripts
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```bash
+pnpm dev              # Start development server
+pnpm build            # Production build
+pnpm lint             # ESLint
+pnpm test             # Unit tests (Vitest)
+pnpm test:coverage    # Unit tests with coverage report
+pnpm test:e2e         # E2E tests (Playwright)
+pnpm prisma generate  # Regenerate Prisma client after schema changes
+pnpm prisma studio    # Open Prisma Studio to browse the database
+```
 
-## Learn More
+## Project Structure
 
-To learn more about Next.js, take a look at the following resources:
+```
+src/
+  app/              # Next.js App Router pages
+    directory/      # Estate browser
+    estate/[id]/    # Estate detail
+    submit/         # Submit an estate
+    dashboard/      # Admin dashboard + verification
+    profile/[id]/   # User profile
+    login/          # Login page
+  auth.ts           # Auth.js server instance (with Prisma adapter)
+  auth.config.ts    # Shared Auth.js config (Edge-compatible)
+prisma/
+  schema.prisma     # Database schema
+  migrations/       # Migration history
+```
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## CI/CD
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+| Workflow | Trigger | Description |
+|---|---|---|
+| CI | Push / PR to `main`, `develop` | Type check, lint, unit tests, E2E tests |
+| Release | Push to `main` | Creates a GitHub release via semantic-release |
+| Sync develop | Push to `main` | Merges `main` back into `develop` |
+| Auto Assign | Issue / PR opened | Assigns the opener as the assignee |
+| Claude Code Review | PR opened | AI-assisted code review |
 
-## Deploy on Vercel
+Commits follow the [Conventional Commits](https://www.conventionalcommits.org/) spec. `semantic-release` determines the version bump automatically.
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## Contributing
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+1. Branch off `develop`
+2. Open a PR targeting `develop`
+3. Releases to `main` are made via a separate release PR from `develop`

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,192 @@
+# Eorzea Estates — Environment Setup Guide
+
+This guide walks through configuring all external services required to run the app locally.
+
+---
+
+## Prerequisites
+
+- [pnpm](https://pnpm.io/installation) installed globally
+- Node.js 18+
+- A Discord account
+- A Cloudinary account (free)
+- A Supabase account (free)
+
+---
+
+## Step 1 — Supabase (PostgreSQL Database)
+
+1. Go to [https://supabase.com](https://supabase.com) and sign in or create an account.
+2. Click **New project**.
+3. Fill in:
+   - **Name:** `eorzea-estates` (or any name you prefer)
+   - **Database Password:** choose a strong password and save it somewhere — you'll need it in the connection strings
+   - **Region:** pick the one closest to you
+   - **Pricing plan:** Free
+4. Click **Create new project** and wait ~2 minutes for provisioning.
+5. Once ready, click the **Connect** button near the top of the project dashboard.
+6. In the modal that opens, click the **Connection String** tab.
+7. Set **Type** to `URI` and **Source** to `Primary Database`.
+8. For `DATABASE_URL` (pooled connection):
+   - Set **Method** to **Transaction pooler**
+   - Copy the connection string. It will look like:
+     ```
+     postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres
+     ```
+   - Append `?pgbouncer=true` to the end and paste as `DATABASE_URL` in your `.env`.
+9. For `DIRECT_URL` (direct connection):
+   - Set **Method** to **Direct connection**
+   - Copy the connection string. It will look like:
+     ```
+     postgresql://postgres:[password]@db.[project-ref].supabase.co:5432/postgres
+     ```
+   - Paste this as `DIRECT_URL` in your `.env`.
+
+Your `.env` should now look like:
+```env
+DATABASE_URL="postgresql://postgres.xxxx:yourpassword@aws-0-us-east-1.pooler.supabase.com:6543/postgres?pgbouncer=true"
+DIRECT_URL="postgresql://postgres.xxxx:yourpassword@aws-0-us-east-1.supabase.com:5432/postgres"
+```
+
+---
+
+## Step 2 — NextAuth Secret
+
+Run this command to generate a random secret:
+
+```bash
+openssl rand -base64 32
+```
+
+Copy the output and paste it as `AUTH_SECRET` in your `.env`:
+
+```env
+AUTH_SECRET="paste-the-generated-value-here"
+```
+
+---
+
+## Step 3 — Discord OAuth Application
+
+1. Go to [https://discord.com/developers/applications](https://discord.com/developers/applications).
+2. Click **New Application** (top-right).
+3. Enter a name: `Eorzea Estates` (or any name you like) and click **Create**.
+4. In the left sidebar, click **OAuth2**.
+5. Under **Redirects**, click **Add Redirect** and enter:
+   ```
+   http://localhost:3000/api/auth/callback/discord
+   ```
+   Click **Save Changes**.
+6. Still on the OAuth2 page, find:
+   - **Client ID** — copy this and paste as `AUTH_DISCORD_ID` in your `.env`
+   - **Client Secret** — click **Reset Secret**, confirm, then copy it and paste as `AUTH_DISCORD_SECRET`
+
+Your `.env` should now look like:
+```env
+AUTH_DISCORD_ID="your-client-id-here"
+AUTH_DISCORD_SECRET="your-client-secret-here"
+```
+
+> **Note:** When you deploy to production, add your production URL as a second redirect:
+> `https://yourdomain.com/api/auth/callback/discord`
+
+---
+
+## Step 4 — Cloudinary (Image Hosting)
+
+1. Go to [https://cloudinary.com](https://cloudinary.com) and sign in or create a free account.
+2. After signing in, you land on the **Dashboard**.
+3. In the **Product Environment Credentials** section you will see:
+   - **Cloud name** → paste as `CLOUDINARY_CLOUD_NAME`
+   - **API key** → paste as `CLOUDINARY_API_KEY`
+   - **API secret** → click the eye icon to reveal it → paste as `CLOUDINARY_API_SECRET`
+
+Your `.env` should now look like:
+```env
+CLOUDINARY_CLOUD_NAME="your-cloud-name"
+CLOUDINARY_API_KEY="123456789012345"
+CLOUDINARY_API_SECRET="your-api-secret-here"
+```
+
+> **Optional — create an upload preset (not required for this app):** The app uses server-side signed uploads, so no preset is needed.
+
+---
+
+## Step 5 — Final .env File
+
+Your completed `.env` should look like this:
+
+```env
+# Supabase PostgreSQL
+DATABASE_URL="postgresql://postgres.xxxx:password@aws-0-us-east-1.pooler.supabase.com:6543/postgres?pgbouncer=true"
+DIRECT_URL="postgresql://postgres.xxxx:password@aws-0-us-east-1.supabase.com:5432/postgres"
+
+# Auth.js / NextAuth
+AUTH_SECRET="your-generated-secret"
+AUTH_DISCORD_ID="your-discord-client-id"
+AUTH_DISCORD_SECRET="your-discord-client-secret"
+
+# Cloudinary
+CLOUDINARY_CLOUD_NAME="your-cloud-name"
+CLOUDINARY_API_KEY="your-api-key"
+CLOUDINARY_API_SECRET="your-api-secret"
+
+# App
+NEXTAUTH_URL="http://localhost:3000"
+```
+
+---
+
+## Step 6 — Run the Database Migration
+
+With the `.env` configured, run:
+
+```bash
+pnpm prisma migrate dev --name init
+```
+
+This creates all the database tables in your Supabase project. You should see output confirming each migration was applied.
+
+To verify the tables were created, go to your Supabase project → **Table Editor** in the left sidebar. You should see tables like `User`, `Estate`, `Image`, `Comment`, `Like`, etc.
+
+---
+
+## Step 7 — Generate the Prisma Client
+
+```bash
+pnpm prisma generate
+```
+
+This regenerates the typed Prisma client from your schema. Run this any time the schema changes.
+
+---
+
+## Step 8 — Start the Dev Server
+
+```bash
+pnpm dev
+```
+
+Open [http://localhost:3000](http://localhost:3000). You should see the homepage. Click **Sign In** and you should be redirected to Discord for authentication.
+
+---
+
+## Troubleshooting
+
+| Problem | Solution |
+|---|---|
+| `PrismaClientInitializationError` | Check `DATABASE_URL` is correct and Supabase project is active |
+| Discord sign-in fails | Verify the redirect URL in Discord matches exactly (including `http://`) |
+| Images fail to upload | Double-check all three `CLOUDINARY_*` values are set |
+| `AUTH_SECRET` error on sign-in | Make sure `AUTH_SECRET` is set and not the placeholder text |
+| Migration fails | Ensure `DIRECT_URL` is set — pooled connections cannot run migrations |
+
+---
+
+## Production Deployment (Later)
+
+When you deploy:
+1. Add all `.env` values to your hosting provider's environment variables
+2. Change `NEXTAUTH_URL` to your production domain
+3. Add the production callback URL to Discord OAuth redirects
+4. Run `pnpm prisma migrate deploy` (not `dev`) on the production database


### PR DESCRIPTION
## Summary

- Replaces the boilerplate `create-next-app` README with a project-specific overview covering features, tech stack, scripts, project structure, and CI/CD workflows
- Adds `SETUP.md` with step-by-step instructions for configuring Supabase, Discord OAuth, and Cloudinary for local development

🤖 Generated with [Claude Code](https://claude.com/claude-code)