### PR TITLE
fix: use SYNC_PAT to bypass branch protection on develop sync

### DIFF
--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           ref: develop
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SYNC_PAT }}
 
       - name: Configure git
         run: |


### PR DESCRIPTION
## Summary

- Replaces `GITHUB_TOKEN` with `SYNC_PAT` in the sync-develop workflow
- `GITHUB_TOKEN` is blocked by the develop branch protection ruleset; a fine-grained PAT owned by the repo admin can bypass it and push directly

## Setup required

Add a repository secret named `SYNC_PAT` containing a fine-grained PAT with **Contents: Read and write** permission scoped to this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)