### PR TITLE
feat: add light/dark/system color theme support

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,7 +34,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen bg-background`}>
         <Providers>
           <Navbar />

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { signOut } from "@/auth"
 import { Home, Plus, LayoutDashboard, User, LogOut } from "lucide-react"
+import { ThemeToggle } from "@/components/theme-toggle"
 
 export default async function Navbar() {
   const session = await auth()
@@ -27,6 +28,8 @@ export default async function Navbar() {
           <Link href="/directory" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
             Browse
           </Link>
+
+          <ThemeToggle />
 
           {session?.user ? (
             <>

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -1,7 +1,14 @@
 "use client"
 
 import { SessionProvider } from "next-auth/react"
+import { ThemeProvider } from "next-themes"
 
 export function Providers({ children }: { children: React.ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>
+  return (
+    <SessionProvider>
+      <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+        {children}
+      </ThemeProvider>
+    </SessionProvider>
+  )
 }

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Sun, Moon, Monitor } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+export function ThemeToggle() {
+  const { setTheme } = useTheme()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" aria-label="Toggle theme">
+          <Sun className="h-4 w-4 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
+          <Moon className="absolute h-4 w-4 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme("light")}>
+          <Sun className="h-4 w-4 mr-2" />
+          Light
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
+          <Moon className="h-4 w-4 mr-2" />
+          Dark
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          <Monitor className="h-4 w-4 mr-2" />
+          System
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}


### PR DESCRIPTION
## Summary

- Wraps the app in `ThemeProvider` from `next-themes` with `defaultTheme="system"` and `enableSystem`
- Adds `suppressHydrationWarning` to `<html>` to prevent theme flicker on load
- Adds a `ThemeToggle` dropdown to the navbar allowing users to switch between Light, Dark, and System options
- No new CSS required — the app already had full `:root` (light) and `.dark` variable sets defined

## Files changed

- `src/components/providers.tsx` — added `ThemeProvider` wrapper
- `src/app/layout.tsx` — added `suppressHydrationWarning`
- `src/components/theme-toggle.tsx` — new toggle component
- `src/components/navbar.tsx` — added `ThemeToggle` to nav

## Test plan

- [x] Toggle between Light, Dark, and System from the navbar
- [x] Verify System matches the OS preference
- [x] Confirm no hydration warnings in the browser console

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)