### PR TITLE
ci: auto-create branch on issue open and close issues on merge to develop

### DIFF
--- a/.github/workflows/auto-branch.yml
+++ b/.github/workflows/auto-branch.yml
@@ -1,0 +1,52 @@
+name: Auto Branch
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  create-branch:
+    name: Create branch for issue
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+
+            const prefixMap = { 'feat:': 'feature', 'fix:': 'fix', 'ci:': 'ci', 'docs:': 'docs', 'chore:': 'chore' };
+            const titleLower = issue.title.toLowerCase();
+            const prefix = Object.entries(prefixMap).find(([k]) => titleLower.startsWith(k))?.[1] ?? 'feature';
+
+            const slug = issue.title
+              .toLowerCase()
+              .replace(/^(feat|fix|ci|docs|chore|style|refactor|test|perf|build|revert):\s*/i, '')
+              .replace(/[^a-z0-9]+/g, '-')
+              .replace(/^-|-$/g, '')
+              .slice(0, 50);
+
+            const branchName = `${prefix}/${issue.number}-${slug}`;
+
+            const { data: ref } = await github.rest.git.getRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'heads/develop',
+            });
+
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/heads/${branchName}`,
+              sha: ref.object.sha,
+            });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: `Branch created: \`${branchName}\``,
+            });

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -1,0 +1,33 @@
+name: Close Issues on Merge to Develop
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [develop]
+
+permissions:
+  issues: write
+
+jobs:
+  close:
+    name: Close linked issues
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body ?? '';
+            const pattern = /(?:closes?|fixes?|resolves?)\s+#(\d+)/gi;
+            const matches = [...body.matchAll(pattern)];
+
+            for (const match of matches) {
+              const issueNumber = parseInt(match[1]);
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+            }


### PR DESCRIPTION
## Summary

- **`auto-branch.yml`** — triggers on `issues.opened`; creates a branch off `develop` named `<prefix>/<issue-number>-<slug>` (prefix inferred from title: `feat:` → `feature/`, `fix:` → `fix/`, etc.); posts a comment on the issue with the branch name
- **`close-issues.yml`** — triggers on `pull_request.closed` targeting `develop`; parses the PR body for `Closes/Fixes/Resolves #X` and closes the referenced issues (GitHub only auto-closes via those keywords when merging into the default branch, which is `main`)

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)