### PR TITLE
ci: require linked issue on pull requests

### DIFF
--- a/.github/workflows/require-issue.yml
+++ b/.github/workflows/require-issue.yml
@@ -1,0 +1,24 @@
+name: Require Linked Issue
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-linked-issue:
+    name: Check for linked issue
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Check PR body for issue reference
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body ?? '';
+            const linked = /(closes|fixes|resolves)\s+#\d+/i.test(body);
+            if (!linked) {
+              core.setFailed(
+                'This PR must reference an issue. Add "Closes #<issue-number>" to the PR description.'
+              );
+            }


### PR DESCRIPTION
## Summary
- Adds a workflow that checks every PR body for a `Closes #N`, `Fixes #N`, or `Resolves #N` reference
- The check fails if no linked issue is found, blocking merge until one is added

## Test plan
- [ ] Open a PR without an issue reference — check should fail
- [ ] Add `Closes #N` to the PR body — check should pass

Closes #24