### PR TITLE
fix: skip linked issue check for PRs targeting main

### DIFF
--- a/.github/workflows/require-issue.yml
+++ b/.github/workflows/require-issue.yml
@@ -8,6 +8,7 @@ jobs:
   check-linked-issue:
     name: Check for linked issue
     runs-on: ubuntu-latest
+    if: github.base_ref != 'main'
     permissions:
       pull-requests: read
     steps:


### PR DESCRIPTION
## Summary

Adds `if: github.base_ref != 'main'` to the `check-linked-issue` job so release PRs (`develop` → `main`) are not required to reference an issue.

All feature and fix PRs targeting `develop` are still enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)