### PR TITLE
feat: add character profile pages and link staff/dashboard to them

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,14 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   serverExternalPackages: ["@xivapi/nodestone", "regex-translator"],
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "img2.finalfantasyxiv.com",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -90,6 +90,7 @@ model FfxivCharacter {
   user   User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   estates Estate[]
   lodestoneVerification LodestoneVerification?
+  venueStaffLinks VenueStaff[] @relation("StaffCharacter")
 
   @@unique([userId, lodestoneId])
 }
@@ -150,7 +151,6 @@ model Estate {
   venueDetails VenueDetails?
   likes        Like[]
   comments     Comment[]
-  staffLinks   VenueStaff[]  @relation("StaffLinkedEstate")
 }
 
 model Image {
@@ -206,9 +206,9 @@ model VenueStaff {
   linkedUserId String?
   linkedUser   User?  @relation("StaffUser", fields: [linkedUserId], references: [id], onDelete: SetNull)
 
-  // Optional: links to that user's estate entry on this site
-  linkedEstateId String?
-  linkedEstate   Estate? @relation("StaffLinkedEstate", fields: [linkedEstateId], references: [id], onDelete: SetNull)
+  // Optional: links to that staff member's character profile on this site
+  linkedCharacterId String?
+  linkedCharacter   FfxivCharacter? @relation("StaffCharacter", fields: [linkedCharacterId], references: [id], onDelete: SetNull)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/app/api/estates/route.ts
+++ b/src/app/api/estates/route.ts
@@ -85,7 +85,7 @@ export async function POST(req: Request) {
                   create: (data.venueStaff ?? []).map((s) => ({
                     characterName: s.characterName,
                     role: s.role,
-                    linkedEstateId: s.linkedEstateId ?? null,
+                    linkedCharacterId: s.linkedCharacterId ?? null,
                   })),
                 },
               },

--- a/src/app/character/[characterId]/page.tsx
+++ b/src/app/character/[characterId]/page.tsx
@@ -1,0 +1,105 @@
+import { Metadata } from "next"
+import { notFound } from "next/navigation"
+import Image from "next/image"
+import prisma from "@/lib/prisma"
+import { EstateCard } from "@/components/estate-card"
+import { BadgeCheck } from "lucide-react"
+
+interface PageProps {
+  params: Promise<{ characterId: string }>
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { characterId } = await params
+  const character = await prisma.ffxivCharacter.findUnique({
+    where: { id: characterId },
+    select: { characterName: true, server: true },
+  })
+  if (!character) return {}
+  return { title: `${character.characterName} (${character.server})` }
+}
+
+export default async function CharacterProfilePage({ params }: PageProps) {
+  const { characterId } = await params
+
+  const character = await prisma.ffxivCharacter.findUnique({
+    where: { id: characterId },
+    select: {
+      id: true,
+      characterName: true,
+      server: true,
+      dataCenter: true,
+      avatarUrl: true,
+      verified: true,
+    },
+  })
+
+  if (!character) notFound()
+
+  const estates = await prisma.estate.findMany({
+    where: { characterId, published: true },
+    orderBy: { createdAt: "desc" },
+    include: {
+      images: { orderBy: { order: "asc" }, take: 1 },
+      venueDetails: { select: { venueType: true } },
+    },
+  })
+
+  return (
+    <div className="container mx-auto max-w-4xl px-4 py-10">
+      <div className="flex items-center gap-4 mb-8">
+        {character.avatarUrl ? (
+          <Image
+            src={character.avatarUrl}
+            alt={character.characterName}
+            width={64}
+            height={64}
+            className="rounded-full"
+          />
+        ) : (
+          <div className="h-16 w-16 rounded-full bg-muted flex items-center justify-center text-2xl font-bold text-muted-foreground">
+            {character.characterName.charAt(0).toUpperCase()}
+          </div>
+        )}
+        <div>
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-bold">{character.characterName}</h1>
+            {character.verified && (
+              <BadgeCheck className="h-5 w-5 text-blue-500" aria-label="Verified character" />
+            )}
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {character.server} &middot; {character.dataCenter}
+          </p>
+          <p className="text-sm text-muted-foreground">
+            {estates.length} estate{estates.length !== 1 ? "s" : ""}
+          </p>
+        </div>
+      </div>
+
+      {estates.length === 0 ? (
+        <p className="text-muted-foreground text-center py-12">No published estates yet.</p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {estates.map((estate) => (
+            <EstateCard
+              key={estate.id}
+              id={estate.id}
+              name={estate.name}
+              type={estate.type}
+              district={estate.district}
+              server={estate.server}
+              dataCenter={estate.dataCenter}
+              tags={estate.tags}
+              likeCount={estate.likeCount}
+              coverImage={estate.images[0]?.cloudinaryUrl}
+              ownerName={character.characterName}
+              lodestoneVerified={character.verified}
+              venueType={estate.venueDetails?.venueType ?? null}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -140,7 +140,7 @@ export default async function DashboardPage() {
                       )}
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-1.5 flex-wrap">
-                          <span className="font-medium truncate">{character.characterName}</span>
+                          <Link href={`/character/${character.id}`} className="font-medium truncate hover:underline">{character.characterName}</Link>
                           {character.verified ? (
                             <Badge variant="default" className="gap-1 shrink-0">
                               <BadgeCheck className="h-3 w-3" />

--- a/src/app/estate/[id]/page.tsx
+++ b/src/app/estate/[id]/page.tsx
@@ -60,8 +60,8 @@ export default async function EstateDetailPage({ params }: PageProps) {
           include: {
             staff: {
               include: {
-                linkedEstate: {
-                  select: { id: true, name: true },
+                linkedCharacter: {
+                  select: { id: true, characterName: true },
                 },
               },
             },
@@ -221,18 +221,16 @@ export default async function EstateDetailPage({ params }: PageProps) {
                   <div className="space-y-2">
                     {estate.venueDetails.staff.map((s) => (
                       <div key={s.id} className="flex items-center justify-between text-sm">
-                        <div>
-                          <span className="font-medium">
-                            {s.linkedEstate ? (
-                              <Link href={`/estate/${s.linkedEstate.id}`} className="hover:underline flex items-center gap-1">
-                                {s.characterName}
-                                <ExternalLink className="h-3 w-3" />
-                              </Link>
-                            ) : (
-                              s.characterName
-                            )}
-                          </span>
-                        </div>
+                        <span className="font-medium">
+                          {s.linkedCharacter ? (
+                            <Link href={`/character/${s.linkedCharacter.id}`} className="hover:underline flex items-center gap-1">
+                              {s.characterName}
+                              <ExternalLink className="h-3 w-3" />
+                            </Link>
+                          ) : (
+                            s.characterName
+                          )}
+                        </span>
                         <span className="text-muted-foreground">{s.role}</span>
                       </div>
                     ))}

--- a/src/app/submit/estate-submit-form.tsx
+++ b/src/app/submit/estate-submit-form.tsx
@@ -390,7 +390,7 @@ export function EstateSubmitForm({ characters }: Props) {
                   type="button"
                   variant="outline"
                   size="sm"
-                  onClick={() => appendStaff({ characterName: "", role: "", linkedEstateId: "" })}
+                  onClick={() => appendStaff({ characterName: "", role: "", linkedCharacterId: "" })}
                 >
                   <Plus className="h-4 w-4 mr-1" />
                   Add Staff Member
@@ -427,10 +427,10 @@ export function EstateSubmitForm({ characters }: Props) {
                         />
                       </div>
                       <div className="col-span-2">
-                        <Label className="text-xs">Linked Estate ID (optional)</Label>
+                        <Label className="text-xs">Character Profile ID (optional)</Label>
                         <Input
-                          {...form.register(`venueStaff.${index}.linkedEstateId`)}
-                          placeholder="Paste estate ID if they have a listing here"
+                          {...form.register(`venueStaff.${index}.linkedCharacterId`)}
+                          placeholder="Character ID from their profile URL (e.g. /character/abc123)"
                           className="mt-1"
                         />
                       </div>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -11,7 +11,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { signOut } from "@/auth"
-import { Plus, LayoutDashboard, User, LogOut } from "lucide-react"
+import { Plus, LayoutDashboard, LogOut } from "lucide-react"
 import { ThemeToggle } from "@/components/theme-toggle"
 
 export default async function Navbar() {
@@ -56,12 +56,6 @@ export default async function Navbar() {
                     <Link href="/dashboard">
                       <LayoutDashboard className="h-4 w-4 mr-2" />
                       Dashboard
-                    </Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem asChild>
-                    <Link href={`/profile/${session.user.id}`}>
-                      <User className="h-4 w-4 mr-2" />
-                      My Profile
                     </Link>
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -13,7 +13,7 @@ export const hoursSchema = z.object({
 export const staffMemberSchema = z.object({
   characterName: z.string().min(1, "Character name is required"),
   role: z.string().min(1, "Role is required"),
-  linkedEstateId: z.string().optional(),
+  linkedCharacterId: z.string().optional(),
 })
 
 export const estateFormSchema = z.object({


### PR DESCRIPTION
## Summary

- Add `/character/[characterId]` public profile page showing avatar, server info, and published estates
- Link character names in the dashboard to their profile pages
- Replace `linkedEstateId` with `linkedCharacterId` on `VenueStaff` so staff entries link to character profiles instead of estate listings
- Remove redundant "My Profile" navbar menu item (dashboard already covers this)
- Allow `img2.finalfantasyxiv.com` in `next/image` remote patterns for Lodestone avatars

## Test plan

- [ ] Navigate to `/character/[id]` — verify avatar, name, server/DC, verified badge, and estate grid render correctly
- [ ] Click a character name in the dashboard — verify it navigates to the character profile page
- [ ] On an estate detail page with staff, verify linked staff names link to `/character/[id]`
- [ ] Submit a venue estate with a staff member linked to a character ID — verify the link appears on the estate page
- [ ] Confirm the "My Profile" item no longer appears in the navbar dropdown
- [ ] Confirm Lodestone avatars load without unconfigured host errors

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)