### PR TITLE
feat: add legal pages, settings section, and brand-link utility

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,184 @@
+# GitHub Copilot Instructions
+
+## Project Overview
+
+This repository is **Eorzea Estates**, a Next.js 16 App Router application for browsing, submitting, and managing Final Fantasy XIV housing listings.
+
+Primary stack:
+
+- Next.js 16 with App Router
+- React 19 and TypeScript
+- Auth.js / NextAuth v5 with Discord OAuth
+- Prisma 7 with PostgreSQL (Supabase)
+- Tailwind CSS v4 with shadcn/ui and Radix UI
+- React Hook Form with Zod
+- Vitest for unit/component tests
+- Playwright for E2E tests
+
+## Development Commands
+
+Prefer `pnpm`.
+
+Common commands:
+
+- `pnpm dev` - start the local dev server
+- `pnpm build` - production build
+- `pnpm lint` - run ESLint
+- `pnpm tsc --noEmit` - type-check
+- `pnpm test` - run Vitest once
+- `pnpm test:watch` - run Vitest in watch mode
+- `pnpm test:coverage` - run Vitest with coverage
+- `pnpm test:e2e` - run Playwright tests
+- `pnpm test:e2e:ui` - run Playwright with UI mode
+- `pnpm prisma generate` - regenerate the Prisma client after schema changes
+- `pnpm prisma migrate dev --name <name>` - create and apply a migration locally
+- `pnpm prisma migrate deploy` - apply migrations in production
+
+## Architecture and File Layout
+
+Important project structure:
+
+- `src/app/` - App Router pages and route handlers
+- `src/app/api/` - API endpoints for auth, estates, comments, likes, uploads, Lodestone verification, characters, cron jobs, and estate transfer
+- `src/auth.config.ts` - edge-safe Auth.js config
+- `src/auth.ts` - full Auth.js setup with Prisma adapter
+- `src/proxy.ts` - route protection for authenticated areas
+- `src/lib/` - Prisma client, validation, FFXIV data, Cloudinary, Lodestone, email, utilities
+- `src/components/` - shared UI and feature components
+- `src/components/ui/` - shadcn/ui primitives
+- `prisma/schema.prisma` - Prisma schema
+- `prisma/migrations/` - committed migration history
+- `src/generated/prisma/` - generated Prisma client output committed to the repo
+- `src/test/` - Vitest test setup, unit tests, and component tests
+- `e2e/` - Playwright tests
+
+## Current Domain Model
+
+The codebase currently includes:
+
+- Users authenticated through Discord
+- Verified FFXIV characters
+- Estate listings tied to a verified character
+- Estate types: `PRIVATE`, `FC_ESTATE`, `VENUE`, `APARTMENT`, `FC_ROOM`
+- Venue-specific details including hours and staff
+- Comments and likes
+- Lodestone verification records
+- Estate pending transfer flow
+
+When suggesting schema-aware code, use the current Prisma schema rather than older assumptions.
+
+## Auth and Route Protection
+
+Follow the existing auth split:
+
+- Keep `src/auth.config.ts` free of Node-only dependencies so it remains safe for edge/runtime use
+- Put Prisma adapter usage and full auth wiring in `src/auth.ts`
+- Use `auth()` from `@/auth` in server components and route handlers when session access is needed
+
+Protected route behavior currently lives in `src/proxy.ts`, not `middleware.ts`.
+
+Protected prefixes:
+
+- `/submit`
+- `/dashboard`
+- `/estate`
+
+Exception:
+
+- `GET /estate/[id]` is public
+
+When adding auth-sensitive features, preserve this pattern unless the surrounding code is explicitly being redesigned.
+
+## Database and Prisma Conventions
+
+- Import Prisma via `@/lib/prisma`
+- Reuse the Prisma singleton from `src/lib/prisma.ts`; do not instantiate new clients ad hoc
+- After schema changes, update migrations and regenerate the client
+- Assume generated Prisma client types come from `src/generated/prisma/`
+- Keep Prisma queries close to the server boundary: server components, route handlers, and server actions
+
+## Validation and Forms
+
+- Shared validation belongs in `src/lib/schemas.ts`
+- Reuse Zod schemas across forms and API handlers instead of duplicating validation
+- Existing forms use `react-hook-form` with `zodResolver`; follow that pattern for new complex forms
+- Estate creation/edit flows should continue to validate against the shared estate schema and the current per-character ownership rules
+
+## UI Conventions
+
+- Prefer server components by default; add `"use client"` only when hooks, browser APIs, or client-side interactivity are required
+- Reuse existing shadcn/ui components from `src/components/ui/` before creating new primitives
+- Use the `cn` helper from `@/lib/utils` for class composition
+- Maintain the existing Tailwind v4 token/theme approach defined in `src/app/globals.css`
+- Preserve current naming and import conventions such as `@/` path aliases
+
+## API and Data Handling
+
+- Route handlers live under `src/app/api/**/route.ts`
+- Return `NextResponse.json(...)` with explicit status codes
+- Validate request payloads before writing to the database
+- Keep authorization checks close to mutations
+- Reuse existing static FFXIV data utilities from `src/lib/ffxiv-data.ts`
+- For Lodestone and character-related features, build on the existing verification flow instead of introducing parallel logic
+
+## Testing Expectations
+
+When changing behavior:
+
+- Add or update Vitest tests in `src/test/unit/` or `src/test/components/`
+- Add or update Playwright coverage in `e2e/` for important user flows
+- Prefer focused tests over broad snapshots
+
+Before finishing a substantial change, the most relevant checks are:
+
+- `pnpm lint`
+- `pnpm tsc --noEmit`
+- `pnpm test`
+- `pnpm test:e2e` when the change affects end-to-end behavior
+
+## Environment Variables
+
+The project expects environment variables in `.env`, including:
+
+- `DATABASE_URL`
+- `DIRECT_URL`
+- `AUTH_SECRET`
+- `AUTH_DISCORD_ID`
+- `AUTH_DISCORD_SECRET`
+- `CLOUDINARY_CLOUD_NAME`
+- `CLOUDINARY_API_KEY`
+- `CLOUDINARY_API_SECRET`
+- `NEXTAUTH_URL`
+
+Refer to `SETUP.md` for local setup details.
+
+## Git and Release Workflow
+
+The repository uses two long-lived branches:
+
+- `main` - production and semantic-release
+- `develop` - staging/integration
+
+Conventions:
+
+- Prefer feature branches like `feature/<description>`
+- Prefer fix branches like `fix/<issue-number>-<description>`
+- Commits should follow Conventional Commits
+- Every PR should be tied to a GitHub issue
+
+Release flow is automated:
+
+- pushes to `main` run semantic-release
+- changelog and release tagging are automated
+- `main` is synced back into `develop`
+
+## Copilot Guidance
+
+When generating suggestions for this repository:
+
+- prefer minimal diffs that fit the existing structure
+- do not replace working patterns with generic boilerplate
+- keep server-only logic out of client components
+- avoid duplicating validation, auth wiring, or Prisma access helpers
+- preserve existing feature-specific behavior around verified characters, estate ownership, venue details, likes, comments, and transfer flows
+- align with current route names and file locations in the repository, not stale documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,25 +57,31 @@ NEXTAUTH_URL          # http://localhost:3000 (dev) or production domain
 
 ### Key Patterns
 
-**Auth split** (`src/auth.config.ts` / `src/auth.ts`): Config is split so `auth.config.ts` can be imported in the Edge-compatible middleware without pulling in Node-only Prisma dependencies. `src/auth.ts` has the full adapter-based setup used in API routes and server components.
+**Auth split** (`src/auth.config.ts` / `src/auth.ts`): Config is split so `auth.config.ts` can be imported in the Edge-compatible auth/proxy layer without pulling in Node-only Prisma dependencies. `src/auth.ts` has the full adapter-based setup used in API routes and server components.
 
-**Protected routes**: `src/middleware.ts` protects `/submit`, `/dashboard`, `/estate` (except GET `/estate/[id]` which is public).
+**Protected routes**: `src/proxy.ts` protects `/submit`, `/dashboard`, `/estate` (except GET `/estate/[id]` which is public).
 
 **Prisma client**: Singleton in `src/lib/prisma.ts`, types from `src/generated/prisma/`. Run `pnpm prisma generate` after any schema change — the generated output is committed to the repo.
 
 **Lodestone verification**: Users can optionally verify their FFXIV character by placing a generated code in their Lodestone bio. Flow: `/api/lodestone/start` issues a code → user pastes it into Lodestone → `/api/lodestone/confirm` polls xivapi.com to verify.
 
-**FFXIV data** (`src/lib/ffxiv-data.ts`): Static data for regions, data centers, servers, housing districts, and ward/plot counts.
+**FFXIV characters and estates**: Estates are tied to verified `FfxivCharacter` records. The current schema supports estate types `PRIVATE`, `FC_ESTATE`, `VENUE`, `APARTMENT`, and `FC_ROOM`, plus venue staff/details and estate transfer flows.
+
+**FFXIV data** (`src/lib/ffxiv-data.ts`): Static data for regions, data centers, servers, housing districts, venue types, tags, and schedule helpers.
 
 **Zod schemas** (`src/lib/schemas.ts`): Shared form validation schemas used by both client forms and API route handlers.
 
 ### API Routes (`src/app/api/`)
 - `auth/[...nextauth]` — NextAuth handler
-- `estates/` — list/create estates; `estates/[id]` — read/update/delete
+- `estates/` — create estates; `estates/[id]` — read/update/delete
 - `comments/[estateId]` — list/post comments
 - `likes/[estateId]` — toggle like
 - `upload` — Cloudinary signed upload
 - `lodestone/start` + `lodestone/confirm` — character verification
+- `characters/` + `characters/[id]` — character management
+- `characters/[id]/reverify-fc` — re-verification flow for FC-related estates
+- `cron/verify-fc-estates` — background verification
+- `estate-transfer/confirm` — estate ownership transfer confirmation
 
 ### Branching and Release Flow
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,7 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    ".claude/**",
   ]),
 ]);
 

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -1,0 +1,81 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+
+export default function CookiePolicyPage() {
+  const router = useRouter();
+  return (
+    <div className="prose mx-auto max-w-2xl px-4 py-12 dark:prose-invert">
+      <button
+        type="button"
+        onClick={() => router.back()}
+        className="flex items-center text-muted-foreground hover:text-primary transition mb-6 w-fit"
+      >
+        <ArrowLeft className="h-5 w-5 mr-1" />
+        <span className="text-base">Back</span>
+      </button>
+      <h1 className="text-2xl font-bold mb-4">Cookie Policy</h1>
+      <p className="text-sm text-muted-foreground mb-8">Last updated: March 8, 2026</p>
+      
+      <div className="space-y-6 text-sm leading-relaxed text-text-dim">
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-2">1. What Are Cookies</h2>
+          <p>Cookies are small text files stored on your device by your web browser. They are used to remember information about your session.</p>
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-2">2. Cookies We Use</h2>
+          <p>Eorzea Estates uses only essential cookies required for the service to function. We do not use any analytics, tracking, advertising, or third-party cookies.</p>
+          <div className="mt-4 rounded-lg border border-border-muted overflow-hidden">
+            <table className="w-full text-left">
+              <thead className="bg-surface-raised">
+                <tr>
+                  <th className="px-4 py-2 text-text font-medium">Cookie</th>
+                  <th className="px-4 py-2 text-text font-medium">Purpose</th>
+                  <th className="px-4 py-2 text-text font-medium">Duration</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border-muted">
+                <tr>
+                  <td className="px-4 py-2 font-mono text-xs">authjs.session-token</td>
+                  <td className="px-4 py-2">Stores your authenticated session (JWT)</td>
+                  <td className="px-4 py-2">30 days</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2 font-mono text-xs">authjs.csrf-token</td>
+                  <td className="px-4 py-2">CSRF protection for authentication forms</td>
+                  <td className="px-4 py-2">Session</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2 font-mono text-xs">authjs.callback-url</td>
+                  <td className="px-4 py-2">Stores redirect URL during OAuth sign-in</td>
+                  <td className="px-4 py-2">Session</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-2">3. Why No Cookie Banner?</h2>
+          <p>Under GDPR (and the ePrivacy Directive), consent is not required for cookies that are strictly necessary for the service to function. Since Eorzea Estates only uses essential authentication cookies, no cookie consent banner is legally required.</p>
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-2">4. Managing Cookies</h2>
+          <p>You can clear or block cookies through your browser settings. Note that blocking session cookies will prevent you from signing in to Eorzea Estates.</p>
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-2">5. Changes To Policy</h2>
+          <p>If we ever add non-essential cookies (analytics, etc.), we will update this policy and implement a proper consent mechanism before doing so.</p>
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-2">6. Contact</h2>
+          <p>If you have any questions about this cookie policy, please contact us at <a href="mailto:privacy@example.com" className="brand-link">privacy@example.com</a>.</p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -140,7 +140,7 @@ export default async function DashboardPage() {
                       )}
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-1.5 flex-wrap">
-                          <Link href={`/character/${character.id}`} className="font-medium truncate hover:underline">{character.characterName}</Link>
+                          <Link href={`/character/${character.id}`} className="brand-link truncate font-medium no-underline">{character.characterName}</Link>
                           {character.verified ? (
                             <Badge variant="default" className="gap-1 shrink-0">
                               <BadgeCheck className="h-3 w-3" />

--- a/src/app/directory/directory-filters.tsx
+++ b/src/app/directory/directory-filters.tsx
@@ -25,12 +25,11 @@ interface Props {
   estateTypes: readonly { value: string; label: string }[]
   districts: readonly { value: string; label: string }[]
   tags: readonly string[]
-  currentParams: Record<string, string | undefined>
 }
 
 const EMPTY = "__all__"
 
-export function DirectoryFilters({ regions, estateTypes, districts, tags, currentParams }: Props) {
+export function DirectoryFilters({ regions, estateTypes, districts, tags }: Props) {
   const router = useRouter()
   const searchParams = useSearchParams()
 

--- a/src/app/directory/page.tsx
+++ b/src/app/directory/page.tsx
@@ -106,7 +106,6 @@ export default async function DirectoryPage({ searchParams }: DirectoryPageProps
               estateTypes={ESTATE_TYPES}
               districts={HOUSING_DISTRICTS}
               tags={PREDEFINED_TAGS}
-              currentParams={params}
             />
           </Suspense>
         </aside>

--- a/src/app/estate/[id]/page.tsx
+++ b/src/app/estate/[id]/page.tsx
@@ -1,7 +1,6 @@
 import { notFound } from "next/navigation"
 import { Metadata } from "next"
 import Link from "next/link"
-import Image from "next/image"
 import { BadgeCheck, MapPin, Clock, Users, ExternalLink } from "lucide-react"
 import prisma from "@/lib/prisma"
 import { auth } from "@/auth"
@@ -152,7 +151,7 @@ export default async function EstateDetailPage({ params }: PageProps) {
       {/* Owner */}
       <div className="flex items-center gap-2 mt-4 text-sm">
         <span className="text-muted-foreground">Listed by</span>
-        <Link href={`/profile/${estate.owner.id}`} className="flex items-center gap-1 hover:underline font-medium">
+        <Link href={`/profile/${estate.owner.id}`} className="brand-link flex items-center gap-1 font-medium no-underline">
           {ownerIsVerified && (
             <BadgeCheck className="h-4 w-4 text-blue-500" />
           )}
@@ -223,7 +222,7 @@ export default async function EstateDetailPage({ params }: PageProps) {
                       <div key={s.id} className="flex items-center justify-between text-sm">
                         <span className="font-medium">
                           {s.linkedCharacter ? (
-                            <Link href={`/character/${s.linkedCharacter.id}`} className="hover:underline flex items-center gap-1">
+                            <Link href={`/character/${s.linkedCharacter.id}`} className="brand-link flex items-center gap-1 no-underline">
                               {s.characterName}
                               <ExternalLink className="h-3 w-3" />
                             </Link>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,6 +23,7 @@
   --color-chart-2: var(--chart-2);
   --color-chart-1: var(--chart-1);
   --color-ring: var(--ring);
+  --color-link: var(--link);
   --color-input: var(--input);
   --color-border: var(--border);
   --color-destructive: var(--destructive);
@@ -67,6 +68,7 @@
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
+  --link: #7a4200;
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
@@ -101,6 +103,7 @@
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);
+  --link: #d09510;
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
@@ -122,5 +125,18 @@
   }
   body {
     @apply bg-background text-foreground;
+  }
+}
+
+@layer utilities {
+  .brand-link {
+    color: var(--link) !important;
+    text-decoration-line: underline;
+    text-underline-offset: 4px;
+    transition: color 150ms ease;
+  }
+
+  .brand-link:hover {
+    color: color-mix(in srgb, var(--link) 80%, transparent) !important;
   }
 }

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,0 +1,124 @@
+
+"use client";
+import { useRouter } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+
+export default function PrivacyPolicyPage() {
+    const router = useRouter();
+    return (
+        <div className="prose mx-auto max-w-2xl px-4 py-12 dark:prose-invert">
+            <button
+                type="button"
+                onClick={() => router.back()}
+                className="flex items-center text-muted-foreground hover:text-primary transition mb-6 w-fit"
+            >
+                <ArrowLeft className="h-5 w-5 mr-1" />
+                <span className="text-base">Back</span>
+            </button>
+            <h1 className="text-2xl font-bold mb-4">Privacy Policy</h1>
+            <p className="text-sm text-muted-foreground mb-8">Last updated: March 8, 2026</p>
+
+            <div className="space-y-6 text-sm leading-relaxed text-text-dim">
+                <section>
+                    <h2 className="text-lg font-semibold text-foreground mb-2">1. Who We Are</h2>
+                    <p>
+                        Eorzea Estates is a fan-made housing directory for Final Fantasy XIV players, operated at eorzeaestates.com. For privacy inquiries, contact us at <a href="mailto:privacy@example.com" className="brand-link">privacy@example.com</a>.
+                    </p>
+                </section>
+
+                <section>
+                    <h2 className="text-lg font-semibold text-foreground mb-2">2. Data We Collect</h2>
+                    <ul className="list-disc pl-5 space-y-1">
+                        <li><strong>Account data:</strong> Discord OAuth profile (user ID, username, avatar, email address)</li>
+                        <li><strong>Character data:</strong> FFXIV character name, server, and profile information fetched from the Lodestone</li>
+                        <li><strong>Lodestone character data:</strong> When you choose to verify a character, we fetch publicly available data (character name, server, Free Company, avatar, etc.) from the FFXIV Lodestone. This data is collected only at your explicit request and is not shared with third parties.</li>
+                        <li><strong>User content:</strong> Estate listings, comments, likes, uploaded images</li>
+                        <li><strong>Technical data:</strong> Session tokens (JWT), timestamps of account creation and activity</li>
+                    </ul>
+                </section>
+
+                <section>
+                    <h2 className="text-lg font-semibold text-foreground mb-2">3. Purpose of Processing</h2>
+                    <ul className="list-disc pl-5 space-y-1">
+                        <li>Providing the estate directory and related services</li>
+                        <li>Authenticating your identity</li>
+                        <li>Displaying character and estate profiles to other users</li>
+                        <li>Sending notifications about account activity</li>
+                    </ul>
+                    <p>
+                        Legal basis (GDPR Art. 6): Consent (account creation), legitimate interest (service operation), and contract performance.
+                    </p>
+                </section>
+
+                <section>
+                    <h2 className="text-lg font-semibold text-foreground mb-2">4. Data Retention</h2>
+                    <p>
+                        We retain your data for as long as your account is active. If you delete your account, all personal data (profile, listings, comments, likes) will be permanently removed within 30 days. Anonymized, aggregated data may be retained for service improvement.
+                    </p>
+                </section>
+
+                <section>
+                    <h2 className="text-lg font-semibold text-foreground mb-2">5. Your Rights (GDPR)</h2>
+                    <ul className="list-disc pl-5 space-y-1">
+                        <li><strong>Access</strong> — Request a copy of all personal data we hold about you</li>
+                        <li><strong>Rectification</strong> — Correct inaccurate or incomplete data</li>
+                        <li><strong>Erasure</strong> — Request deletion of your personal data (&quot;right to be forgotten&quot;)</li>
+                        <li><strong>Portability</strong> — Receive your data in a structured, machine-readable format</li>
+                        <li><strong>Restriction</strong> — Request limited processing of your data</li>
+                        <li><strong>Objection</strong> — Object to processing based on legitimate interest</li>
+                    </ul>
+                    <p>
+                        To exercise any of these rights, email <a href="mailto:privacy@example.com" className="brand-link">privacy@example.com</a>. We will respond within 30 days.
+                    </p>
+                </section>
+
+                <section>
+                    <h2 className="text-lg font-semibold text-foreground mb-2">6. Cookies</h2>
+                    <p>
+                        Eorzea Estates uses only essential session cookies required for authentication (NextAuth.js). We do not use analytics, tracking, or advertising cookies. See our <a href="/settings/cookie-policy" className="brand-link">Cookie Policy</a> for details.
+                    </p>
+                </section>
+
+                <section>
+                    <h2 className="text-lg font-semibold text-foreground mb-2">7. Third-Party Services</h2>
+                    <ul className="list-disc pl-5 space-y-1">
+                        <li>
+                            <strong>Discord OAuth:</strong> If you sign in with Discord, we receive your email, username, and avatar. See <a href="https://discord.com/privacy" className="brand-link" target="_blank" rel="noopener noreferrer">Discord&apos;s Privacy Policy</a>.
+                        </li>
+                        <li>
+                            <strong>FFXIV Lodestone:</strong> When you verify a character, we access publicly available profile pages on <span className="underline">na.finalfantasyxiv.com</span>. No authentication or private data from Square Enix is accessed. Only data visible on public Lodestone profiles is retrieved.
+                        </li>
+                    </ul>
+                </section>
+
+                <section>
+                    <h2 className="text-lg font-semibold text-foreground mb-2">8. Data Security</h2>
+                    <p>
+                        We use HTTPS encryption in transit, OAuth authentication, and JWT-based stateless sessions. Access to the database is restricted to authorized personnel only.
+                    </p>
+                </section>
+
+                <section>
+                    <h2 className="text-lg font-semibold text-foreground mb-2">9. Children</h2>
+                    <p>
+                        Eorzea Estates is not intended for users under 18 years of age. We do not knowingly collect data from children.
+                    </p>
+                </section>
+
+                <section>
+                    <h2 className="text-lg font-semibold text-foreground mb-2">10. Changes to This Policy</h2>
+                    <p>
+                        We may update this policy from time to time. Significant changes will be communicated via the platform. Continued use after changes constitutes acceptance.
+                    </p>
+                </section>
+
+                <section>
+                    <h2 className="text-lg font-semibold text-foreground mb-2">11. Contact</h2>
+                    <p>
+                        For any privacy-related questions or requests, contact us at <a href="mailto:privacy@example.com" className="brand-link">privacy@example.com</a>.
+                    </p>
+                </section>
+            </div>
+        </div>
+    );
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+import { Shield, Lock, FileText, Cookie, ChevronRight } from "lucide-react";
+
+export default function SettingsPage() {
+  return (
+    <div className="max-w-xl mx-auto py-12 px-4">
+      <h1 className="text-3xl font-bold mb-8 text-primary">Settings</h1>
+      <section className="bg-card rounded-xl p-6 mb-8">
+        <div className="flex items-center mb-6">
+          <Shield className="brand-link mr-3" />
+          <h2 className="text-lg font-semibold text-primary">Legal & Privacy</h2>
+        </div>
+        <ul className="space-y-4">
+          <li>
+            <Link href="/privacy-policy" className="flex items-center group justify-between hover:bg-accent rounded-lg px-3 py-2 transition">
+              <span className="flex items-center">
+                <Lock className="mr-3 text-muted-foreground group-hover:text-primary transition" />
+                <span className="text-foreground">Privacy Policy</span>
+              </span>
+              <ChevronRight className="mr-3 text-muted-foreground group-hover:text-primary transition" />
+            </Link>
+          </li>
+          <li>
+            <Link href="/terms-of-service" className="flex items-center group justify-between hover:bg-accent rounded-lg px-3 py-2 transition">
+              <span className="flex items-center">
+                <FileText className="mr-3 text-muted-foreground group-hover:text-primary transition" />
+                <span className="text-foreground">Terms of Service</span>
+              </span>
+              <ChevronRight className="mr-3 text-muted-foreground group-hover:text-primary transition" />
+            </Link>
+          </li>
+          <li>
+            <Link href="/cookie-policy" className="flex items-center group justify-between hover:bg-accent rounded-lg px-3 py-2 transition">
+              <span className="flex items-center">
+                <Cookie className="mr-3 text-muted-foreground group-hover:text-primary transition" />
+                <span className="text-foreground">Cookie Policy</span>
+              </span>
+              <ChevronRight className="mr-3 text-muted-foreground group-hover:text-primary transition" />
+            </Link>
+          </li>
+        </ul>
+      </section>
+      {/* More settings sections can be added here */}
+    </div>
+  );
+}

--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -1,0 +1,119 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+
+export default function TermsOfServicePage() {
+  const router = useRouter();
+  return (
+    <div className="max-w-2xl mx-auto py-12 px-4">
+      <button
+        type="button"
+        onClick={() => router.back()}
+        className="flex items-center text-muted-foreground hover:text-primary transition mb-6 w-fit"
+      >
+        <ArrowLeft className="h-5 w-5 mr-1" />
+        <span className="text-base">Back</span>
+      </button>
+      <h1 className="text-2xl font-bold mb-4">Terms of Service</h1>
+      <p className="text-sm text-muted-foreground mb-8">Last updated: March 8, 2026</p>
+
+      <div className="space-y-6 text-sm leading-relaxed text-text-dim">
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-2">1. Acceptance of Terms</h2>
+          <p>By creating an account or using Eorzea Estates, you agree to these Terms of Service. If you do not agree, please do not use the platform.</p>
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-2">2. Description of Service</h2>
+          <p>Eorzea Estates is a fan-made housing directory for Final Fantasy XIV players. It allows users to create estate listings linked to their FFXIV characters, browse other estates, and interact with the community.</p>
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-2">3. Account Rules</h2>
+          <ul className="list-disc pl-5 space-y-1">
+              <li>You must be at least 18 years old to create an account</li>
+              <li>You are responsible for maintaining the security of your account</li>
+              <li>One account per person — duplicate accounts may be removed</li>
+              <li>You must provide accurate information during registration</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-2">4. User Conduct</h2>
+          <ul className="list-disc pl-5 space-y-1">
+              <li>Do not harass, bully, or send unsolicited inappropriate content to other users</li>
+              <li>Do not impersonate other players or use someone else&apos;s FFXIV character</li>
+              <li>Do not upload illegal, explicit, or offensive content</li>
+              <li>Do not use the platform for commercial purposes, spam, or solicitation</li>
+              <li>Do not attempt to exploit, hack, or disrupt the service</li>
+              <li>Do not scrape or collect data from the platform without authorization</li>
+          </ul>
+          <p className="mt-2">Violation of these rules may result in a warning, profile reset, or immediate account termination.</p>
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-2">5. Lodestone Data & Third-Party Content</h2>
+          <p>Eorzea Estates allows users to import their FFXIV character data from the publicly accessible FFXIV Lodestone service operated by Square Enix. This import is performed solely at the user&apos;s explicit request.</p>
+          <p className="mt-2">By importing a character, you confirm that you are the rightful owner of that character. Importing characters belonging to other players without their consent is prohibited and may result in account termination.</p>
+          <p className="mt-2">Eorzea Estates does not store, cache, or redistribute Lodestone data in bulk. Character data is fetched on-demand and displayed only within the user&apos;s profile or estate listing on the platform.</p>
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-2">6. Profile Moderation</h2>
+          <ul className="list-disc pl-5 space-y-1">
+              <li>Administrators may send warnings to users whose profiles or behavior do not align with the platform&apos;s purpose</li>
+              <li>Profiles may be reset (removing all profile data including name, bio, avatar, and tags) if the content is deemed inappropriate, irrelevant, or in violation of these terms</li>
+              <li>Uploaded avatars or images may be removed</li>
+              <li>Accounts may be suspended or banned</li>
+          </ul>
+          <p className="mt-2">Users whose profiles are reset will need to set up their profile again. This action is non-reversible. We encourage users to create profiles and listings that are relevant to FFXIV and the Eorzea Estates community.</p>
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-2">7. Intellectual Property Disclaimer</h2>
+          <p>FINAL FANTASY is a registered trademark of Square Enix Holdings Co., Ltd. FINAL FANTASY XIV © SQUARE ENIX CO., LTD. All FFXIV-related content, images, names, and assets are the property of Square Enix.</p>
+          <p className="mt-2">Eorzea Estates is a fan-made project and is <strong>not affiliated with, endorsed by, or sponsored by Square Enix</strong>. All character data displayed is publicly available via the Lodestone.</p>
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-2">8. User Content</h2>
+          <p>You retain ownership of content you upload (profile text, images). By uploading, you grant Eorzea Estates a non-exclusive license to display it within the platform. You may delete your content at any time.</p>
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-2">9. Limitation of Liability</h2>
+          <ul className="list-disc pl-5 space-y-1">
+              <li>Eorzea Estates is provided &quot;as is&quot; without warranties of any kind</li>
+              <li>We are not responsible for interactions between users (online or offline)</li>
+              <li>We are not responsible for loss of data due to technical issues</li>
+              <li>We are not responsible for service interruptions or downtime</li>
+              <li>We are not responsible for third-party content or services linked from the platform</li>
+          </ul>
+          <p className="mt-2">To the maximum extent permitted by law, our total liability is limited to zero, as this is a free, non-commercial service.</p>
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-2">10. Termination</h2>
+          <p>You may delete your account at any time from your settings page. We reserve the right to suspend or terminate accounts that violate these terms, without prior notice. Upon termination, your data will be handled according to our <a href="/privacy-policy" className="text-primary underline">Privacy Policy</a>.</p>
+        </section>
+ 
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-2">11. Changes to Terms</h2>
+          <p>We reserve the right to modify, update, or replace these Terms of Service at any time, for any reason, without prior notice. Changes take effect immediately upon publication.</p>
+          <p className="mt-2">All updates to these terms will be communicated through the Changelog section available in the app&apos;s Settings page. It is your responsibility to periodically review the Changelog and these Terms for any changes.</p>
+          <p className="mt-2">Your continued use of Eorzea Estates after any changes constitutes your acceptance of the updated terms. If you do not agree with the new terms, you must stop using the platform and delete your account.</p>
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-2">12. Governing Law</h2>
+          <p>These terms are governed by the laws of the United States and applicable state legislation. Any disputes shall be resolved in accordance with applicable U.S. regulations.</p>
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold text-foreground mb-2">13. Contact</h2>
+          <p>Questions about these terms? Contact us at <a href="mailto:privacy@example.com" className="brand-link">privacy@example.com</a>.</p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/components/comments-section.tsx
+++ b/src/components/comments-section.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react"
 import { useRouter } from "next/navigation"
-import Image from "next/image"
 import { formatDistanceToNow } from "date-fns"
 import { toast } from "sonner"
 import { BadgeCheck } from "lucide-react"

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -16,7 +16,7 @@ export default function Footer() {
             href="https://ko-fi.com/caspiannightworth"
             target="_blank"
             rel="noopener noreferrer"
-            className="underline underline-offset-4 hover:text-foreground transition-colors"
+            className="brand-link"
           >
             Support on Ko-fi
           </a>

--- a/src/components/image-upload.tsx
+++ b/src/components/image-upload.tsx
@@ -4,7 +4,6 @@ import { useState, useRef, useCallback } from "react"
 import Image from "next/image"
 import { toast } from "sonner"
 import { X, GripVertical, ImagePlus, Loader2 } from "lucide-react"
-import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 
 export interface UploadedImage {

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -11,7 +11,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { signOut } from "@/auth"
-import { Plus, LayoutDashboard, LogOut } from "lucide-react"
+import { Plus, LayoutDashboard, LogOut, Settings as SettingsIcon } from "lucide-react"
 import { ThemeToggle } from "@/components/theme-toggle"
 
 export default async function Navbar() {
@@ -56,6 +56,12 @@ export default async function Navbar() {
                     <Link href="/dashboard">
                       <LayoutDashboard className="h-4 w-4 mr-2" />
                       Dashboard
+                    </Link>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem asChild>
+                    <Link href="/settings">
+                      <SettingsIcon className="h-4 w-4 mr-2" />
+                      Settings
                     </Link>
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -17,7 +17,7 @@ const badgeVariants = cva(
         outline:
           "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
         ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 [a&]:hover:underline",
+        link: "text-link underline-offset-4 [a&]:hover:text-link/80 [a&]:hover:underline",
       },
     },
     defaultVariants: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,7 +18,7 @@ const buttonVariants = cva(
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost:
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
+        link: "text-link underline-offset-4 hover:text-link/80 hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",


### PR DESCRIPTION
## Summary

- Add Privacy Policy, Terms of Service, and Cookie Policy pages
- Add `/settings` page with a Legal & Privacy section linking to all three
- Add Settings link to the navbar user dropdown
- Add `brand-link` CSS utility for themed link color (amber in light mode, gold in dark mode)
- Fix `DirectoryFilters`: remove unused `currentParams` prop and remove the stale call site in `directory/page.tsx`
- Update `CLAUDE.md` with latest API routes and architecture notes

## Test plan

- [ ] Visit `/settings` — confirm Legal & Privacy section shows all three links
- [ ] Visit `/privacy-policy`, `/terms-of-service`, `/cookie-policy` — confirm pages render and back button works
- [ ] Confirm Settings link appears in the navbar user dropdown when signed in
- [ ] Confirm `brand-link` styled links render correctly in light and dark mode
- [ ] Confirm directory page filters still work correctly

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)