### PR TITLE
fix: replace hardcoded back link with router.back() on legal pages

### DIFF
--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -1,5 +1,4 @@
-import Link from "next/link"
-import { ArrowLeft } from "lucide-react"
+import { BackButton } from "@/components/back-button"
 import prisma from "@/lib/prisma"
 import { LEGAL_DEFAULTS } from "@/lib/legal-defaults"
 import { LegalPageRenderer } from "@/components/legal-page-renderer"
@@ -11,13 +10,7 @@ export default async function CookiePolicyPage() {
 
   return (
     <div className="max-w-2xl mx-auto px-4 py-12">
-      <Link
-        href="/settings"
-        className="flex items-center text-muted-foreground hover:text-primary transition mb-6 w-fit"
-      >
-        <ArrowLeft className="h-5 w-5 mr-1" />
-        <span className="text-base">Back</span>
-      </Link>
+      <BackButton />
       <h1 className="text-2xl font-bold mb-4">Cookie Policy</h1>
       <p className="text-sm text-muted-foreground mb-8">
         Last updated:{" "}

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,5 +1,4 @@
-import Link from "next/link"
-import { ArrowLeft } from "lucide-react"
+import { BackButton } from "@/components/back-button"
 import prisma from "@/lib/prisma"
 import { LEGAL_DEFAULTS } from "@/lib/legal-defaults"
 import { LegalPageRenderer } from "@/components/legal-page-renderer"
@@ -11,13 +10,7 @@ export default async function PrivacyPolicyPage() {
 
   return (
     <div className="max-w-2xl mx-auto px-4 py-12">
-      <Link
-        href="/settings"
-        className="flex items-center text-muted-foreground hover:text-primary transition mb-6 w-fit"
-      >
-        <ArrowLeft className="h-5 w-5 mr-1" />
-        <span className="text-base">Back</span>
-      </Link>
+      <BackButton />
       <h1 className="text-2xl font-bold mb-4">Privacy Policy</h1>
       <p className="text-sm text-muted-foreground mb-8">
         Last updated:{" "}

--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -1,5 +1,4 @@
-import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
+import { BackButton } from "@/components/back-button";
 import prisma from "@/lib/prisma";
 import { LEGAL_DEFAULTS } from "@/lib/legal-defaults";
 import { LegalPageRenderer } from "@/components/legal-page-renderer";
@@ -11,13 +10,7 @@ export default async function TermsOfServicePage() {
 
   return (
     <div className="max-w-2xl mx-auto px-4 py-12">
-      <Link
-        href="/settings"
-        className="flex items-center text-muted-foreground hover:text-primary transition mb-6 w-fit"
-      >
-        <ArrowLeft className="h-5 w-5 mr-1" />
-        <span className="text-base">Back</span>
-      </Link>
+      <BackButton />
       <h1 className="text-2xl font-bold mb-4">Terms of Service</h1>
       <p className="text-sm text-muted-foreground mb-8">
         Last updated:{" "}

--- a/src/components/back-button.tsx
+++ b/src/components/back-button.tsx
@@ -1,0 +1,18 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { ArrowLeft } from "lucide-react"
+
+export function BackButton() {
+  const router = useRouter()
+  return (
+    <button
+      type="button"
+      onClick={() => router.back()}
+      className="flex items-center text-muted-foreground hover:text-primary transition mb-6 w-fit"
+    >
+      <ArrowLeft className="h-5 w-5 mr-1" />
+      <span className="text-base">Back</span>
+    </button>
+  )
+}


### PR DESCRIPTION
## Summary
- Extracts a `BackButton` client component using `router.back()` so users return to wherever they came from
- Replaces the hardcoded `<Link href="/settings">` back button on all three legal pages (ToS, Privacy Policy, Cookie Policy)

## Test plan
- [ ] Navigate to a legal page from settings — Back returns to settings
- [ ] Navigate to a legal page from somewhere else — Back returns to that page

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)