### PR TITLE
fix: region and data center filters not updating URL correctly

### DIFF
--- a/src/app/directory/directory-filters.tsx
+++ b/src/app/directory/directory-filters.tsx
@@ -158,9 +158,13 @@ export function DirectoryFilters({ regions, estateTypes, districts, tags }: Prop
         <Select
           value={selectedRegion || EMPTY}
           onValueChange={(v) => {
-            update("region", v === EMPTY ? null : v)
-            update("dataCenter", null)
-            update("server", null)
+            const params = new URLSearchParams(searchParams.toString())
+            params.delete("page")
+            if (v === EMPTY) params.delete("region")
+            else params.set("region", v)
+            params.delete("dataCenter")
+            params.delete("server")
+            router.push(`/directory?${params.toString()}`)
           }}
         >
           <SelectTrigger>
@@ -178,8 +182,12 @@ export function DirectoryFilters({ regions, estateTypes, districts, tags }: Prop
           <Select
             value={selectedDC || EMPTY}
             onValueChange={(v) => {
-              update("dataCenter", v === EMPTY ? null : v)
-              update("server", null)
+              const params = new URLSearchParams(searchParams.toString())
+              params.delete("page")
+              if (v === EMPTY) params.delete("dataCenter")
+              else params.set("dataCenter", v)
+              params.delete("server")
+              router.push(`/directory?${params.toString()}`)
             }}
           >
             <SelectTrigger>


### PR DESCRIPTION
## Summary

- Selecting a Region in the directory filter had no effect — the page didn't filter results
- Root cause: the region `onValueChange` handler called `update()` three times in sequence. Each call builds a new `URLSearchParams` from the same stale `searchParams` closure and calls `router.push()` independently. The last push (clearing `server`) won, discarding the region selection entirely.
- Same bug affected the Data Center selector (called `update()` twice).
- Fix: replaced the multiple `update()` calls with a single in-place `URLSearchParams` mutation + one `router.push()` for both selectors.

## Test plan

- [ ] Go to `/directory`
- [ ] Select a Region (e.g. "North America") — results should filter immediately
- [ ] Select a Data Center within that region — results should filter further
- [ ] Select a Server — results should filter further
- [ ] Changing Region should clear Data Center and Server selections
- [ ] Changing Data Center should clear Server selection
- [ ] Other filters (type, district, tags, search) are unaffected

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)