### PR TITLE
feat: add estate edit page for estate owners

### DIFF
--- a/src/app/api/estates/[id]/route.ts
+++ b/src/app/api/estates/[id]/route.ts
@@ -1,7 +1,56 @@
 import { auth } from "@/auth"
 import prisma from "@/lib/prisma"
 import { deleteEstateImage } from "@/lib/cloudinary"
+import { estateFormSchema } from "@/lib/schemas"
 import { NextResponse } from "next/server"
+
+const editEstateSchema = estateFormSchema.omit({ characterId: true })
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const { id } = await params
+  const estate = await prisma.estate.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      inspiration: true,
+      type: true,
+      district: true,
+      ward: true,
+      plot: true,
+      room: true,
+      tags: true,
+      published: true,
+      characterId: true,
+      ownerId: true,
+      images: { orderBy: { order: "asc" }, select: { cloudinaryUrl: true, cloudinaryPublicId: true } },
+      venueDetails: {
+        select: {
+          venueType: true,
+          timezone: true,
+          hours: true,
+          staff: { select: { characterName: true, role: true, linkedCharacterId: true } },
+        },
+      },
+    },
+  })
+
+  if (!estate) return NextResponse.json({ error: "Not found" }, { status: 404 })
+  if (estate.ownerId !== session.user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  return NextResponse.json(estate)
+}
 
 export async function DELETE(
   _req: Request,
@@ -54,7 +103,7 @@ export async function PATCH(
 
   const body = await req.json()
 
-  // Only allow toggling published for now (full edit handled separately)
+  // Toggle published (used by dashboard)
   if (typeof body.published === "boolean") {
     const updated = await prisma.estate.update({
       where: { id },
@@ -64,5 +113,78 @@ export async function PATCH(
     return NextResponse.json(updated)
   }
 
-  return NextResponse.json({ error: "No valid fields to update" }, { status: 400 })
+  // Full edit
+  const parsed = editEstateSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const data = parsed.data
+  const isVenue = data.type === "VENUE"
+
+  // Sync images: delete removed ones from Cloudinary, then replace all DB records
+  const existing = await prisma.estate.findUnique({
+    where: { id },
+    select: { images: { select: { cloudinaryPublicId: true } } },
+  })
+  const newPublicIds = new Set(data.images.map((img) => img.publicId))
+  const toDelete = (existing?.images ?? []).filter((img) => !newPublicIds.has(img.cloudinaryPublicId))
+  await Promise.allSettled(toDelete.map((img) => deleteEstateImage(img.cloudinaryPublicId)))
+
+  const updated = await prisma.estate.update({
+    where: { id },
+    data: {
+      name: data.name,
+      description: data.description,
+      inspiration: data.inspiration ?? "",
+      type: data.type,
+      district: data.district ?? null,
+      ward: data.ward ?? null,
+      plot: data.plot ?? null,
+      room: data.room ?? null,
+      tags: data.tags,
+      images: {
+        deleteMany: {},
+        create: data.images.map((img, i) => ({
+          cloudinaryUrl: img.url,
+          cloudinaryPublicId: img.publicId,
+          order: i,
+        })),
+      },
+      venueDetails: isVenue && data.venueType
+        ? {
+            upsert: {
+              create: {
+                venueType: data.venueType,
+                timezone: data.venueTimezone ?? "UTC",
+                hours: data.venueHours ?? {},
+                staff: {
+                  create: (data.venueStaff ?? []).map((s) => ({
+                    characterName: s.characterName,
+                    role: s.role,
+                    linkedCharacterId: s.linkedCharacterId ?? null,
+                  })),
+                },
+              },
+              update: {
+                venueType: data.venueType,
+                timezone: data.venueTimezone ?? "UTC",
+                hours: data.venueHours ?? {},
+                staff: {
+                  deleteMany: {},
+                  create: (data.venueStaff ?? []).map((s) => ({
+                    characterName: s.characterName,
+                    role: s.role,
+                    linkedCharacterId: s.linkedCharacterId ?? null,
+                  })),
+                },
+              },
+            },
+          }
+        : { delete: true },
+    },
+    select: { id: true },
+  })
+
+  return NextResponse.json(updated)
 }

--- a/src/app/estate/[id]/edit/page.tsx
+++ b/src/app/estate/[id]/edit/page.tsx
@@ -1,0 +1,107 @@
+import { Metadata } from "next"
+import { notFound, redirect } from "next/navigation"
+import { auth } from "@/auth"
+import prisma from "@/lib/prisma"
+import { EstateSubmitForm } from "@/app/submit/estate-submit-form"
+import type { EstateFormValues } from "@/lib/schemas"
+import type { z } from "zod"
+import { estateFormSchema } from "@/lib/schemas"
+
+export const metadata: Metadata = { title: "Edit Estate" }
+
+type EstateFormInput = z.input<typeof estateFormSchema>
+
+export default async function EditEstatePage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const session = await auth()
+  if (!session?.user?.id) redirect("/login")
+
+  const [estate, characters] = await Promise.all([
+    prisma.estate.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        inspiration: true,
+        type: true,
+        district: true,
+        ward: true,
+        plot: true,
+        room: true,
+        tags: true,
+        characterId: true,
+        ownerId: true,
+        images: { orderBy: { order: "asc" }, select: { cloudinaryUrl: true, cloudinaryPublicId: true } },
+        venueDetails: {
+          select: {
+            venueType: true,
+            timezone: true,
+            hours: true,
+            staff: { select: { characterName: true, role: true, linkedCharacterId: true } },
+          },
+        },
+      },
+    }),
+    prisma.ffxivCharacter.findMany({
+      where: { userId: session.user.id, verified: true },
+      orderBy: { createdAt: "asc" },
+      select: { id: true, characterName: true, server: true },
+    }),
+  ])
+
+  if (!estate) notFound()
+  if (estate.ownerId !== session.user.id) redirect("/")
+
+  const defaultValues: Partial<EstateFormInput> = {
+    characterId: estate.characterId ?? "",
+    name: estate.name,
+    description: estate.description,
+    inspiration: estate.inspiration ?? "",
+    type: estate.type as EstateFormValues["type"],
+    district: (estate.district ?? undefined) as EstateFormValues["district"],
+    ward: estate.ward ?? undefined,
+    plot: estate.plot ?? undefined,
+    room: estate.room ?? undefined,
+    tags: estate.tags,
+    images: estate.images.map((img) => ({
+      url: img.cloudinaryUrl,
+      publicId: img.cloudinaryPublicId,
+    })),
+    ...(estate.venueDetails
+      ? {
+          venueType: estate.venueDetails.venueType as EstateFormValues["venueType"],
+          venueTimezone: estate.venueDetails.timezone,
+          venueHours: estate.venueDetails.hours as EstateFormValues["venueHours"],
+          venueStaff: estate.venueDetails.staff.map((s) => ({
+            characterName: s.characterName,
+            role: s.role,
+            linkedCharacterId: s.linkedCharacterId ?? "",
+          })),
+        }
+      : {
+          venueStaff: [],
+          venueTimezone: "UTC",
+        }),
+  }
+
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-10">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold">Edit Estate</h1>
+        <p className="text-muted-foreground mt-1">
+          Update your estate listing. All fields marked with * are required.
+        </p>
+      </div>
+      <EstateSubmitForm
+        characters={characters}
+        estateId={id}
+        defaultValues={defaultValues}
+      />
+    </div>
+  )
+}

--- a/src/app/submit/estate-submit-form.tsx
+++ b/src/app/submit/estate-submit-form.tsx
@@ -42,11 +42,14 @@ interface Character {
 
 interface Props {
   characters: Character[]
+  estateId?: string
+  defaultValues?: Partial<EstateFormInput>
 }
 
-export function EstateSubmitForm({ characters }: Props) {
+export function EstateSubmitForm({ characters, estateId, defaultValues }: Props) {
   const router = useRouter()
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const isEditing = !!estateId
 
   const form = useForm<EstateFormInput, unknown, EstateFormValues>({
     resolver: zodResolver(estateFormSchema),
@@ -60,6 +63,7 @@ export function EstateSubmitForm({ characters }: Props) {
       images: [],
       venueStaff: [],
       venueTimezone: "UTC",
+      ...defaultValues,
     },
   })
 
@@ -86,22 +90,22 @@ export function EstateSubmitForm({ characters }: Props) {
   async function onSubmit(values: EstateFormValues) {
     setIsSubmitting(true)
     try {
-      const res = await fetch("/api/estates", {
-        method: "POST",
+      const res = await fetch(isEditing ? `/api/estates/${estateId}` : "/api/estates", {
+        method: isEditing ? "PATCH" : "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(values),
       })
 
       if (!res.ok) {
         const err = await res.json()
-        throw new Error(err.error?.message ?? "Submission failed")
+        throw new Error(err.error?.message ?? (isEditing ? "Update failed" : "Submission failed"))
       }
 
       const { id } = await res.json()
-      toast.success("Estate submitted successfully!")
-      router.push(`/estate/${id}`)
+      toast.success(isEditing ? "Estate updated!" : "Estate submitted successfully!")
+      router.push(`/estate/${isEditing ? estateId : id}`)
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Submission failed")
+      toast.error(err instanceof Error ? err.message : (isEditing ? "Update failed" : "Submission failed"))
     } finally {
       setIsSubmitting(false)
     }
@@ -115,26 +119,38 @@ export function EstateSubmitForm({ characters }: Props) {
           <CardTitle>Character *</CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-sm text-muted-foreground mb-3">
-            Select the FFXIV character this estate belongs to. Housing limits are enforced per character.
-          </p>
-          <Select
-            value={form.watch("characterId")}
-            onValueChange={(v) => form.setValue("characterId", v, { shouldValidate: true })}
-          >
-            <SelectTrigger>
-              <SelectValue placeholder="Select character" />
-            </SelectTrigger>
-            <SelectContent>
-              {characters.map((c) => (
-                <SelectItem key={c.id} value={c.id}>
-                  {c.characterName} <span className="text-muted-foreground">({c.server})</span>
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          {form.formState.errors.characterId && (
-            <p className="text-destructive text-sm mt-1">{form.formState.errors.characterId.message}</p>
+          {isEditing ? (
+            <p className="text-sm text-muted-foreground">
+              {characters.find((c) => c.id === form.watch("characterId"))?.characterName ?? "Unknown"}{" "}
+              <span className="opacity-60">
+                ({characters.find((c) => c.id === form.watch("characterId"))?.server ?? ""})
+              </span>
+              <span className="block mt-1 text-xs">Character cannot be changed after submission.</span>
+            </p>
+          ) : (
+            <>
+              <p className="text-sm text-muted-foreground mb-3">
+                Select the FFXIV character this estate belongs to. Housing limits are enforced per character.
+              </p>
+              <Select
+                value={form.watch("characterId")}
+                onValueChange={(v) => form.setValue("characterId", v, { shouldValidate: true })}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select character" />
+                </SelectTrigger>
+                <SelectContent>
+                  {characters.map((c) => (
+                    <SelectItem key={c.id} value={c.id}>
+                      {c.characterName} <span className="text-muted-foreground">({c.server})</span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {form.formState.errors.characterId && (
+                <p className="text-destructive text-sm mt-1">{form.formState.errors.characterId.message}</p>
+              )}
+            </>
           )}
         </CardContent>
       </Card>
@@ -257,6 +273,7 @@ export function EstateSubmitForm({ characters }: Props) {
                 max={30}
                 placeholder="1–30"
                 className="mt-1"
+                value={form.watch("ward") ?? ""}
                 onChange={(e) =>
                   form.setValue("ward", e.target.value ? parseInt(e.target.value) : undefined)
                 }
@@ -272,6 +289,7 @@ export function EstateSubmitForm({ characters }: Props) {
                   max={60}
                   placeholder="1–60"
                   className="mt-1"
+                  value={form.watch("plot") ?? ""}
                   onChange={(e) =>
                     form.setValue("plot", e.target.value ? parseInt(e.target.value) : undefined)
                   }
@@ -287,6 +305,7 @@ export function EstateSubmitForm({ characters }: Props) {
                   min={1}
                   placeholder="Room #"
                   className="mt-1"
+                  value={form.watch("room") ?? ""}
                   onChange={(e) =>
                     form.setValue("room", e.target.value ? parseInt(e.target.value) : undefined)
                   }
@@ -372,6 +391,7 @@ export function EstateSubmitForm({ characters }: Props) {
                     <Input
                       placeholder="e.g. 8pm–11pm or Closed"
                       className="max-w-xs"
+                      value={form.watch(`venueHours.${day.key}`) ?? ""}
                       onChange={(e) =>
                         form.setValue(`venueHours.${day.key}`, e.target.value || null)
                       }
@@ -453,7 +473,9 @@ export function EstateSubmitForm({ characters }: Props) {
       )}
 
       <Button type="submit" size="lg" className="w-full" disabled={isSubmitting}>
-        {isSubmitting ? "Submitting..." : "Submit Estate"}
+        {isSubmitting
+          ? isEditing ? "Saving..." : "Submitting..."
+          : isEditing ? "Save Changes" : "Submit Estate"}
       </Button>
     </form>
   )


### PR DESCRIPTION
## Summary

- `/estate/[id]/edit` previously 404'd — now renders a fully pre-populated edit form
- Reuses `EstateSubmitForm` with new `estateId` + `defaultValues` props; PATCHes instead of POSTing when in edit mode
- Character is shown read-only in edit mode (can't be changed post-submission)
- Ward/plot/room and venue hours inputs made controlled so existing values populate correctly
- `GET /api/estates/[id]` added to load estate data for the edit page
- `PATCH /api/estates/[id]` expanded to handle full edits: syncs images (deletes removed ones from Cloudinary), upserts venue details, replaces staff list
- Edit page is owner-only: 404 on unknown estate, redirect to `/` for non-owners

## Test plan

- [ ] Navigate to `/estate/[id]/edit` as the estate owner — form should be pre-filled with all existing data
- [ ] Edit name, description, type, location, tags — save should update and redirect to estate detail page
- [ ] Remove an image and save — image should be gone from the estate and deleted from Cloudinary
- [ ] Add a new image and save — new image appears
- [ ] Edit a VENUE estate — venue type, hours, timezone, and staff should be pre-filled and editable
- [ ] Navigate to `/estate/[id]/edit` as a non-owner — should redirect to `/`
- [ ] The Edit option in the dashboard dropdown should now work correctly

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)