### PR TITLE
fix: clarify moderation action button labels

### DIFF
--- a/src/app/admin/moderation/moderation-actions.tsx
+++ b/src/app/admin/moderation/moderation-actions.tsx
@@ -22,7 +22,7 @@ export function ModerationActions({ estateId }: Props) {
         body: JSON.stringify({ action }),
       })
       if (!res.ok) throw new Error("Failed")
-      const labels = { approve: "Approved", reject: "Rejected", remove: "Removed" }
+      const labels = { approve: "Report dismissed", reject: "Estate unpublished", remove: "Estate removed" }
       toast.success(`${labels[action]} successfully`)
       router.refresh()
     } catch {
@@ -41,7 +41,7 @@ export function ModerationActions({ estateId }: Props) {
         disabled={!!loading}
         onClick={() => handleAction("approve")}
       >
-        {loading === "approve" ? "..." : "Approve"}
+        {loading === "approve" ? "..." : "Dismiss"}
       </Button>
       <Button
         size="sm"
@@ -50,7 +50,7 @@ export function ModerationActions({ estateId }: Props) {
         disabled={!!loading}
         onClick={() => handleAction("reject")}
       >
-        {loading === "reject" ? "..." : "Reject"}
+        {loading === "reject" ? "..." : "Unpublish"}
       </Button>
       <Button
         size="sm"

--- a/src/app/admin/moderation/page.tsx
+++ b/src/app/admin/moderation/page.tsx
@@ -29,7 +29,7 @@ export default async function ModerationPage() {
     <div>
       <h1 className="text-2xl font-bold mb-2">Moderation Queue</h1>
       <p className="text-sm text-muted-foreground mb-6">
-        Review flagged estates. Approve to clear the flag, Reject to unpublish, Remove to delete.
+        Review flagged estates. Dismiss to clear the report, Unpublish to take it down, Remove to delete.
       </p>
 
       {flaggedEstates.length === 0 ? (


### PR DESCRIPTION
## Summary
- Rename **Approve** → **Dismiss** (dismiss the report — estate is fine, no action taken)
- Rename **Reject** → **Unpublish** (take the estate down without deleting it)
- Update the page description to match the new labels

## Test plan
- [ ] Visit `/admin/moderation` and verify buttons read Dismiss / Unpublish / Remove
- [ ] Dismiss a flagged estate — flag is cleared, estate stays published
- [ ] Unpublish a flagged estate — estate is unpublished
- [ ] Remove a flagged estate — estate is deleted

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)