### PR TITLE
fix: bypass maintenance mode check for /images paths in root layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,7 +42,7 @@ export default async function RootLayout({
   // DB-based maintenance mode (runtime toggle via admin settings)
   const headersList = await headers()
   const pathname = headersList.get("x-pathname") ?? ""
-  const bypassPaths = ["/login", "/api/auth", "/maintenance"]
+  const bypassPaths = ["/login", "/api/auth", "/maintenance", "/images"]
   if (!bypassPaths.some((p) => pathname.startsWith(p))) {
     let maintenanceOn = false
     let isAdmin = false


### PR DESCRIPTION
## Summary

- Adds `/images` to `bypassPaths` in the root layout's maintenance mode check

## Root cause

When a request for a static file under `/images/` reaches the App Router (file missing, CDN miss, or any edge case), the root layout runs the DB maintenance check with `pathname = ""` because the middleware matcher excludes `/images/` paths from running — meaning the `x-pathname` header is never set. An empty pathname matched none of the bypass paths, so maintenance mode would redirect the request to `/maintenance` instead of serving the asset. This caused the email logo image to appear broken when the site was in maintenance mode.

## Test plan

- [ ] Enable maintenance mode
- [ ] Trigger a moderation action that sends an email
- [ ] Verify the email logo renders correctly

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)