### PR TITLE
fix: revert email logo to eorzea-estates-navbar.svg

### DIFF
--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -22,7 +22,7 @@ function baseTemplate(title: string, body: string) {
           <!-- Header -->
           <tr>
             <td style="background:#1a1a2e;padding:20px 32px;border-bottom:1px solid #262626;">
-              <img src="https://eorzeaestates.com/images/logo/navbar-email-dark.png" alt="Eorzea Estates" height="48" style="display:block;height:48px;width:auto;" />
+              <img src="https://eorzeaestates.com/images/logo/eorzea-estates-navbar.svg" alt="Eorzea Estates" height="48" style="display:block;height:48px;width:auto;" />
             </td>
           </tr>
           <!-- Body -->


### PR DESCRIPTION
## Summary

- Reverts the email header logo from `navbar-email-dark.png` back to `eorzea-estates-navbar.svg`

The PNG was being blocked by the email provider. The SVG renders correctly and looks better.

## Test plan

- [ ] Trigger a moderation email (unpublish or remove an estate)
- [ ] Verify the logo appears correctly in the email

🤖 Generated with [Claude Code](https://claude.com/claude-code)