### PR TITLE
chore: automate prisma migrate deploy on vercel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "prisma migrate deploy && next build",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint",
     "postinstall": "prisma generate",

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "buildCommand": "prisma migrate deploy && next build",
   "crons": [
     {
       "path": "/api/cron/verify-fc-estates",


### PR DESCRIPTION
## Summary
- Prepends `prisma migrate deploy` to the Vercel build command so DB migrations are applied automatically on every deploy
- Requires `DIRECT_URL` env var to be set in Vercel (already configured)

## Test plan
- [ ] Verify Vercel build succeeds with the updated build command
- [ ] Confirm migrations are applied on deploy

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)