### PR TITLE
release: automate prisma migrations on vercel deploy

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "buildCommand": "prisma migrate deploy && next build",
   "crons": [
     {
       "path": "/api/cron/verify-fc-estates",


### PR DESCRIPTION
## Summary
- Adds `prisma migrate deploy` to Vercel's build command via `vercel.json` so DB migrations run automatically on every deploy
- Keeps `package.json` build script as `next build` so CI is unaffected

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)