### PR TITLE
feat: add message book tag to predefined estate tags

### DIFF
--- a/src/lib/ffxiv-data.ts
+++ b/src/lib/ffxiv-data.ts
@@ -132,6 +132,7 @@ export const PREDEFINED_TAGS = [
   "Gallery",
   "Studio",
   "Lounge",
+  "Message Book",
 ] as const
 
 export const DAYS_OF_WEEK = [


### PR DESCRIPTION
## Summary
- Adds "Message Book" to `PREDEFINED_TAGS` in `ffxiv-data.ts`
- Immediately available as a selectable tag when adding/editing an estate
- Displays as a badge on estate cards and profile pages
- Filterable in the directory via existing tag search — no backend changes needed

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)