### PR TITLE
fix: use deleteMany to avoid P2025 when saving non-venue estate

### DIFF
--- a/src/app/api/estates/[id]/route.ts
+++ b/src/app/api/estates/[id]/route.ts
@@ -161,6 +161,10 @@ export async function PATCH(
     )
   }
 
+  if (!isVenue || !data.venueType) {
+    await prisma.venueDetails.deleteMany({ where: { estateId: id } })
+  }
+
   const updated = await prisma.estate.update({
     where: { id },
     data: {
@@ -181,37 +185,39 @@ export async function PATCH(
           order: i,
         })),
       },
-      venueDetails: isVenue && data.venueType
+      ...(isVenue && data.venueType
         ? {
-            upsert: {
-              create: {
-                venueType: data.venueType,
-                timezone: data.venueTimezone ?? "UTC",
-                hours: data.venueHours ?? {},
-                staff: {
-                  create: (data.venueStaff ?? []).map((s) => ({
-                    characterName: s.characterName,
-                    role: s.role,
-                    linkedCharacterId: s.linkedCharacterId ?? null,
-                  })),
+            venueDetails: {
+              upsert: {
+                create: {
+                  venueType: data.venueType,
+                  timezone: data.venueTimezone ?? "UTC",
+                  hours: data.venueHours ?? {},
+                  staff: {
+                    create: (data.venueStaff ?? []).map((s) => ({
+                      characterName: s.characterName,
+                      role: s.role,
+                      linkedCharacterId: s.linkedCharacterId ?? null,
+                    })),
+                  },
                 },
-              },
-              update: {
-                venueType: data.venueType,
-                timezone: data.venueTimezone ?? "UTC",
-                hours: data.venueHours ?? {},
-                staff: {
-                  deleteMany: {},
-                  create: (data.venueStaff ?? []).map((s) => ({
-                    characterName: s.characterName,
-                    role: s.role,
-                    linkedCharacterId: s.linkedCharacterId ?? null,
-                  })),
+                update: {
+                  venueType: data.venueType,
+                  timezone: data.venueTimezone ?? "UTC",
+                  hours: data.venueHours ?? {},
+                  staff: {
+                    deleteMany: {},
+                    create: (data.venueStaff ?? []).map((s) => ({
+                      characterName: s.characterName,
+                      role: s.role,
+                      linkedCharacterId: s.linkedCharacterId ?? null,
+                    })),
+                  },
                 },
               },
             },
           }
-        : { delete: true },
+        : {}),
     },
     select: { id: true },
   })


### PR DESCRIPTION
## Summary
- Replaces `venueDetails: { delete: true }` (which throws P2025 if no record exists) with a separate `venueDetails.deleteMany` call before the update
- `deleteMany` is a no-op when no VenueDetails record exists, so non-venue and venue estates both save correctly

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)