### PR TITLE
feat: add changelog page to settings

### DIFF
--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -1,0 +1,19 @@
+import { readFileSync } from "fs"
+import { join } from "path"
+import { Metadata } from "next"
+import { BackButton } from "@/components/back-button"
+import { ChangelogRenderer } from "@/components/changelog-renderer"
+
+export const metadata: Metadata = { title: "Changelog" }
+
+export default function ChangelogPage() {
+  const raw = readFileSync(join(process.cwd(), "CHANGELOG.md"), "utf-8")
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-12">
+      <BackButton />
+      <h1 className="text-2xl font-bold mb-8">Changelog</h1>
+      <ChangelogRenderer content={raw} />
+    </div>
+  )
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Shield, Lock, FileText, Cookie, ChevronRight, Database } from "lucide-react";
+import { Shield, Lock, FileText, Cookie, ChevronRight, Database, ScrollText } from "lucide-react";
 import { DataExportButton } from "@/components/data-export-button";
 
 export default function SettingsPage() {
@@ -16,6 +16,24 @@ export default function SettingsPage() {
           Per our Privacy Policy, you can request a copy of all personal data we hold on your account — including your profile, estates, characters, comments, and likes.
         </p>
         <DataExportButton />
+      </section>
+
+      <section className="bg-card rounded-xl p-6 mb-8">
+        <div className="flex items-center mb-6">
+          <ScrollText className="brand-link mr-3" />
+          <h2 className="text-lg font-semibold text-primary">About</h2>
+        </div>
+        <ul className="space-y-4">
+          <li>
+            <Link href="/changelog" className="flex items-center group justify-between hover:bg-accent rounded-lg px-3 py-2 transition">
+              <span className="flex items-center">
+                <ScrollText className="mr-3 text-muted-foreground group-hover:text-primary transition" />
+                <span className="text-foreground">Changelog</span>
+              </span>
+              <ChevronRight className="mr-3 text-muted-foreground group-hover:text-primary transition" />
+            </Link>
+          </li>
+        </ul>
       </section>
 
       <section className="bg-card rounded-xl p-6 mb-8">

--- a/src/components/changelog-renderer.tsx
+++ b/src/components/changelog-renderer.tsx
@@ -1,0 +1,55 @@
+import ReactMarkdown from "react-markdown"
+import remarkGfm from "remark-gfm"
+
+interface Props {
+  content: string
+}
+
+export function ChangelogRenderer({ content }: Props) {
+  return (
+    <div className="space-y-8 text-sm leading-relaxed">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          h1: () => null,
+          h2: ({ children }) => (
+            <h2 className="text-lg font-semibold text-foreground border-b border-border pb-2 mt-8 first:mt-0">
+              {children}
+            </h2>
+          ),
+          h3: ({ children }) => (
+            <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mt-4 mb-2">
+              {children}
+            </h3>
+          ),
+          p: ({ children }) => <p className="text-muted-foreground">{children}</p>,
+          ul: ({ children }) => (
+            <ul className="space-y-1 pl-4 list-disc marker:text-muted-foreground/50">
+              {children}
+            </ul>
+          ),
+          li: ({ children }) => (
+            <li className="text-foreground/80">{children}</li>
+          ),
+          a: ({ href, children }) => (
+            <a
+              href={href}
+              className="brand-link"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {children}
+            </a>
+          ),
+          code: ({ children }) => (
+            <code className="font-mono text-xs bg-muted px-1 py-0.5 rounded">
+              {children}
+            </code>
+          ),
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `/changelog` page that reads `CHANGELOG.md` from the filesystem at request time and renders it with markdown formatting
- New `ChangelogRenderer` component styles version headings, feature/fix sections, and commit links cleanly
- Settings page gets a new **About** section with a Changelog link, placed above the existing Legal & Privacy section

## Test plan

- [ ] Navigate to Settings — "About" section with a Changelog link appears above Legal & Privacy
- [ ] Click Changelog — page loads and displays all version entries with features/bug fixes
- [ ] Links to GitHub commits/issues open in a new tab
- [ ] Back button returns to previous page

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)