### PR TITLE
feat: increase estate image upload limit from 10 to 50

### DIFF
--- a/src/components/image-upload.tsx
+++ b/src/components/image-upload.tsx
@@ -25,7 +25,7 @@ interface ImageUploadProps {
   pathContext?: ImagePathContext
 }
 
-export function ImageUpload({ value, onChange, maxImages = 10, pathContext }: ImageUploadProps) {
+export function ImageUpload({ value, onChange, maxImages = 50, pathContext }: ImageUploadProps) {
   const [uploading, setUploading] = useState(false)
   const [dragOver, setDragOver] = useState(false)
   const [draggingIndex, setDraggingIndex] = useState<number | null>(null)

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -29,7 +29,7 @@ export const estateFormSchema = z.object({
   tags: z.array(z.string()).max(10).default([]),
   images: z.array(
     z.object({ url: z.string().url(), storageKey: z.string() })
-  ).min(1, "At least one screenshot is required").max(10),
+  ).min(1, "At least one screenshot is required").max(50),
   // Venue-specific
   venueType: z.enum(["BAR", "NIGHTCLUB", "CAFE", "RESTAURANT", "GALLERY", "LIBRARY", "SHOP", "BATHHOUSE", "INN", "OTHER"]).optional(),
   venueTimezone: z.string().default("UTC"),

--- a/src/test/unit/schemas.test.ts
+++ b/src/test/unit/schemas.test.ts
@@ -34,8 +34,8 @@ describe("estateFormSchema", () => {
     expect(result.success).toBe(false)
   })
 
-  it("rejects more than 10 images", () => {
-    const images = Array.from({ length: 11 }, (_, i) => ({
+  it("rejects more than 50 images", () => {
+    const images = Array.from({ length: 51 }, (_, i) => ({
       url: `https://test.supabase.co/storage/v1/object/public/estate-images/test/img${i}.webp`,
       storageKey: `test/img${i}.webp`,
     }))


### PR DESCRIPTION
## Summary
- Raises `images` max in the Zod schema from 10 → 50
- Updates `ImageUpload` component default from 10 → 50
- Updates the unit test to assert rejection at 51 images

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)