### PR TITLE
fix: redirect to dashboard after editing an estate

### DIFF
--- a/src/app/submit/estate-submit-form.tsx
+++ b/src/app/submit/estate-submit-form.tsx
@@ -114,7 +114,7 @@ export function EstateSubmitForm({ characters, estateId, defaultValues }: Props)
 
       const { id } = await res.json()
       toast.success(isEditing ? "Estate updated!" : "Estate submitted! Verify ownership from your dashboard to publish.")
-      router.push(isEditing ? `/estate/${estateId}` : "/dashboard")
+      router.push("/dashboard")
     } catch (err) {
       toast.error(err instanceof Error ? err.message : (isEditing ? "Update failed" : "Submission failed"))
     } finally {


### PR DESCRIPTION
## Summary
After saving edits to an unpublished estate, the user was redirected to `/estate/:id` which returns 404 since the estate isn't publicly visible. Changed to always redirect to `/dashboard` after a successful edit — the dashboard is the right landing spot regardless of published state.

## Test plan
- [ ] Edit an unpublished estate → save → lands on `/dashboard` ✓
- [ ] Edit a published estate → save → lands on `/dashboard` ✓

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)