### PR TITLE
fix: use AI_GATEWAY_API_KEY for Vercel AI Gateway auth

### DIFF
--- a/src/lib/ai-verification.ts
+++ b/src/lib/ai-verification.ts
@@ -13,10 +13,14 @@ function getAnthropic() {
     return createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
   }
 
+  // VERCEL_OIDC_TOKEN is auto-injected by Vercel when available.
+  // AI_GATEWAY_API_KEY is an explicit API Gateway Key for production fallback.
+  const token = process.env.VERCEL_OIDC_TOKEN ?? process.env.AI_GATEWAY_API_KEY ?? ""
+
   return createAnthropic({
     baseURL: `${gatewayUrl}/v1`,
-    apiKey: "not-used", // BYOK is configured in Vercel; gateway forwards the Anthropic key
-    headers: { Authorization: `Bearer ${process.env.VERCEL_OIDC_TOKEN ?? ""}` },
+    apiKey: "not-used", // provider key is managed by the gateway (BYOK)
+    headers: { Authorization: `Bearer ${token}` },
   })
 }
 


### PR DESCRIPTION
## Summary
The gateway auth was sending an empty Bearer token because:
- `VERCEL_OIDC_TOKEN` is not being auto-injected in this project
- The code had no fallback to the actual key

The `AI_GATEWAY_API_KEY` env var is already set in Vercel's Production environment. This change uses it as the fallback when `VERCEL_OIDC_TOKEN` is absent.

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)