### PR TITLE
fix: fetch OIDC token at runtime via getVercelOidcToken()

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@prisma/client": "^7.4.2",
     "@supabase/supabase-js": "^2.99.1",
     "@uiw/react-md-editor": "^4.0.11",
+    "@vercel/functions": "^3.4.3",
     "@vercel/speed-insights": "^2.0.0",
     "@xivapi/nodestone": "^0.2.7",
     "ai": "^6.0.116",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@uiw/react-md-editor':
         specifier: ^4.0.11
         version: 4.0.11(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@vercel/functions':
+        specifier: ^3.4.3
+        version: 3.4.3
       '@vercel/speed-insights':
         specifier: ^2.0.0
         version: 2.0.0(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
@@ -2838,8 +2841,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vercel/functions@3.4.3':
+    resolution: {integrity: sha512-kA14KIUVgAY6VXbhZ5jjY+s0883cV3cZqIU3WhrSRxuJ9KvxatMjtmzl0K23HK59oOUjYl7HaE/eYMmhmqpZzw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-web-identity': '*'
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-web-identity':
+        optional: true
+
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+    engines: {node: '>= 20'}
+
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
 
   '@vercel/speed-insights@2.0.0':
@@ -10065,7 +10081,13 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vercel/functions@3.4.3':
+    dependencies:
+      '@vercel/oidc': 3.2.0
+
   '@vercel/oidc@3.1.0': {}
+
+  '@vercel/oidc@3.2.0': {}
 
   '@vercel/speed-insights@2.0.0(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
     optionalDependencies:

--- a/src/lib/ai-verification.ts
+++ b/src/lib/ai-verification.ts
@@ -1,29 +1,29 @@
 import { generateText } from "ai"
 import { createAnthropic } from "@ai-sdk/anthropic"
+import { getVercelOidcToken } from "@vercel/functions/oidc"
 
-// Vercel AI Gateway authentication uses OIDC only (not API keys):
-//   - In production/preview on Vercel: VERCEL_OIDC_TOKEN is auto-provided
-//   - Locally: run `vercel env pull` to write VERCEL_OIDC_TOKEN to .env.local
-// The gateway handles BYOK (forwarding your Anthropic key), so we don't send ANTHROPIC_API_KEY
-// when routing through the gateway. The model name needs the "anthropic/" provider prefix.
-// @ai-sdk/anthropic appends /messages to baseURL, so we append /v1 to reach /v1/messages.
-function getAnthropic() {
+// Uses Vercel AI Gateway when VERCEL_AI_GATEWAY_URL is set.
+// OIDC token is fetched at runtime via getVercelOidcToken() — not an env var.
+// Falls back to direct Anthropic API (ANTHROPIC_API_KEY) if OIDC is unavailable.
+async function buildProvider(): Promise<{ model: ReturnType<ReturnType<typeof createAnthropic>> }> {
   const gatewayUrl = process.env.VERCEL_AI_GATEWAY_URL
-  if (!gatewayUrl) {
-    return createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
+
+  if (gatewayUrl) {
+    try {
+      const token = await getVercelOidcToken()
+      const anthropic = createAnthropic({
+        baseURL: `${gatewayUrl}/v1`,
+        apiKey: "not-used",
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      return { model: anthropic("anthropic/claude-opus-4-5") }
+    } catch {
+      // OIDC unavailable — fall through to direct API
+    }
   }
 
-  return createAnthropic({
-    baseURL: `${gatewayUrl}/v1`,
-    apiKey: "not-used", // provider key is managed by the gateway (BYOK)
-    headers: { Authorization: `Bearer ${process.env.VERCEL_OIDC_TOKEN ?? ""}` },
-  })
-}
-
-function getModel() {
-  return process.env.VERCEL_AI_GATEWAY_URL
-    ? `anthropic/claude-opus-4-5`
-    : `claude-opus-4-5`
+  const anthropic = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
+  return { model: anthropic("claude-opus-4-5") }
 }
 
 interface VerificationContext {
@@ -117,10 +117,10 @@ export async function analyzeVerificationScreenshot(
   imageUrl: string,
   ctx: VerificationContext
 ): Promise<VerificationResult> {
-  const anthropic = getAnthropic()
+  const { model } = await buildProvider()
 
   const { text } = await generateText({
-    model: anthropic(getModel()),
+    model,
     experimental_telemetry: {
       isEnabled: true,
       functionId: "verify-estate-screenshot",


### PR DESCRIPTION
## Summary
`VERCEL_OIDC_TOKEN` is not an environment variable — it must be fetched programmatically at runtime using `getVercelOidcToken()` from `@vercel/functions/oidc`. The previous code was reading a `process.env` key that is never set.

### Changes
- Adds `@vercel/functions` dependency
- Replaces `process.env.VERCEL_OIDC_TOKEN` with `await getVercelOidcToken()`
- Falls back to direct `ANTHROPIC_API_KEY` if OIDC is unavailable (local dev, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)