### PR TITLE
fix: remove redundant verified text and align badge placement

### DIFF
--- a/src/app/estate/[id]/page.tsx
+++ b/src/app/estate/[id]/page.tsx
@@ -166,9 +166,6 @@ export default async function EstateDetailPage({ params }: PageProps) {
           )}
           {ownerDisplayName}
         </Link>
-        {ownerIsVerified && (
-          <span className="text-xs text-muted-foreground">(verified character)</span>
-        )}
       </div>
 
       <Separator className="my-6" />

--- a/src/app/profile/[userId]/page.tsx
+++ b/src/app/profile/[userId]/page.tsx
@@ -66,7 +66,6 @@ export default async function ProfilePage({ params }: PageProps) {
         </Avatar>
         <div>
           <div className="flex items-center gap-2">
-            <h1 className="text-2xl font-bold">{displayName}</h1>
             {user.pathfinder && <PathfinderBadge size="md" />}
             {user.role === "ADMIN" && (
               <Crown className="h-5 w-5 text-yellow-500" aria-label="Admin" />
@@ -77,6 +76,7 @@ export default async function ProfilePage({ params }: PageProps) {
             {isVerified && (
               <BadgeCheck className="h-5 w-5 text-blue-500" aria-label="Verified FFXIV Character" />
             )}
+            <h1 className="text-2xl font-bold">{displayName}</h1>
           </div>
 
           <p className="text-sm text-muted-foreground">{estates.length} estate{estates.length !== 1 ? "s" : ""}</p>


### PR DESCRIPTION
## Summary
- Removes `(verified character)` text from the estate detail page — the `BadgeCheck` icon is self-explanatory
- Moves profile page badges (Pathfinder, Admin, Moderator, Verified) to the **left** of the name, consistent with how they appear in comments

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)