### PR TITLE
feat: make admin user names links to their profiles

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -2,6 +2,7 @@ import { auth } from "@/auth"
 import { redirect } from "next/navigation"
 import prisma from "@/lib/prisma"
 import Image from "next/image"
+import Link from "next/link"
 import { UserRoleSelect } from "./user-role-select"
 import { PathfinderToggle } from "./pathfinder-toggle"
 import { PATHFINDER_LIMIT } from "@/lib/pathfinder"
@@ -75,7 +76,9 @@ export default async function AdminUsersPage() {
                       </div>
                     )}
                     <div>
-                      <p className="font-medium">{user.name ?? "Unknown"}</p>
+                      <Link href={`/profile/${user.id}`} className="brand-link font-medium">
+                        {user.name ?? "Unknown"}
+                      </Link>
                     </div>
                   </div>
                 </td>


### PR DESCRIPTION
## Summary
- User names on the admin Users & Roles page are now links to their public profile (`/profile/[userId]`)

## Test plan
- [ ] Visit `/admin/users` and click a user name — should navigate to their profile page

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)