### PR TITLE
fix: replace Promise.all with prisma.$transaction to avoid MaxClientsInSessionMode

### DIFF
--- a/src/app/admin/moderation/page.tsx
+++ b/src/app/admin/moderation/page.tsx
@@ -21,7 +21,7 @@ export default async function ModerationPage({ searchParams }: PageProps) {
   const { tab } = await searchParams
   const activeTab = tab === "deleted" ? "deleted" : tab === "verification" ? "verification" : tab === "claims" ? "claims" : "flagged"
 
-  const [flaggedEstates, deletedEstates, verificationQueue, claimQueue] = await Promise.all([
+  const [flaggedEstates, deletedEstates, verificationQueue, claimQueue] = await prisma.$transaction([
     prisma.estate.findMany({
       where: { flagged: true, deletedAt: null },
       orderBy: { flaggedAt: "asc" },

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -3,7 +3,7 @@ import prisma from "@/lib/prisma"
 import { Users, FileText, ShieldCheck, Flag } from "lucide-react"
 
 export default async function AdminDashboardPage() {
-  const [userCount, estateCount, moderatorCount, flaggedCount] = await Promise.all([
+  const [userCount, estateCount, moderatorCount, flaggedCount] = await prisma.$transaction([
     prisma.user.count(),
     prisma.estate.count(),
     prisma.user.count({ where: { role: "MODERATOR" } }),

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -64,7 +64,7 @@ export default async function DashboardPage() {
   const session = await auth()
   if (!session?.user?.id) redirect("/login")
 
-  const [characters, estates, likedEstates, collections] = await Promise.all([
+  const [characters, estates, likedEstates, collections] = await prisma.$transaction([
     prisma.ffxivCharacter.findMany({
       where: { userId: session.user.id },
       orderBy: { createdAt: "asc" },


### PR DESCRIPTION
## Summary

Hotfix for pool exhaustion causing upload failures for users.

`Promise.all` with multiple parallel Prisma queries each claim a separate PgBouncer session-mode connection. When several of these pages are hit concurrently, the pool fills up and all subsequent DB calls (including uploads) are rejected with `MaxClientsInSessionMode`.

**Fix:** Replace `Promise.all` with `prisma.$transaction([...])` so all queries in each page share a single connection.

## Affected pages
- `/admin` — 4 parallel count queries
- `/admin/moderation` — 4 parallel findMany queries
- `/dashboard` — 4 parallel queries

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)