### PR TITLE
fix: limit pg.Pool to max:1 to prevent serverless connection exhaustion

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,10 +1,13 @@
 import { PrismaClient } from "../generated/prisma/client"
 import { PrismaPg } from "@prisma/adapter-pg"
+import { Pool } from "pg"
 
 function createPrismaClient() {
-  const adapter = new PrismaPg({
+  const pool = new Pool({
     connectionString: process.env.DATABASE_URL!,
+    max: 1,
   })
+  const adapter = new PrismaPg(pool)
   return new PrismaClient({ adapter })
 }
 


### PR DESCRIPTION
## Root Cause

`PrismaPg` creates a `pg.Pool` with `max: 10` by default. In Vercel serverless, `globalThis.prisma` is **not shared between concurrent function invocations** — each cold start creates its own pool. Under load:

> 5 concurrent invocations × 10 pool connections = **50 connections**

Supabase's session-mode limit is quickly exhausted, causing all subsequent DB calls — including uploads — to fail with `MaxClientsInSessionMode`.

## Fix

Pass an explicit `pg.Pool` with `max: 1` to `PrismaPg`. A serverless function only ever executes one query at a time, so one connection is all it needs.

## Test plan
- [ ] Deploy to preview and confirm uploads succeed under concurrent load
- [ ] Check Supabase connection count stays low while browsing multiple pages

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)