### PR TITLE
fix: convert remaining Promise.all prisma queries to $transaction

### DIFF
--- a/src/app/directory/page.tsx
+++ b/src/app/directory/page.tsx
@@ -55,7 +55,7 @@ export default async function DirectoryPage({ searchParams }: DirectoryPageProps
       ? { updatedAt: "desc" as const }
       : { createdAt: "desc" as const }
 
-  const dbResult = await Promise.all([
+  const dbResult = await prisma.$transaction([
     prisma.estate.findMany({
       where,
       orderBy,

--- a/src/app/estate/[id]/edit/page.tsx
+++ b/src/app/estate/[id]/edit/page.tsx
@@ -21,7 +21,7 @@ export default async function EditEstatePage({
   const session = await auth()
   if (!session?.user?.id) redirect("/login")
 
-  const [estate, rawCharacters] = await Promise.all([
+  const [estate, rawCharacters] = await prisma.$transaction([
     prisma.estate.findUnique({
       where: { id, deletedAt: null },
       select: {

--- a/src/app/estate/[id]/page.tsx
+++ b/src/app/estate/[id]/page.tsx
@@ -40,7 +40,7 @@ export default async function EstateDetailPage({ params }: PageProps) {
   const { id } = await params
   const session = await auth()
 
-  const [estate, comments] = await Promise.all([
+  const [estate, comments] = await prisma.$transaction([
     prisma.estate.findUnique({
       where: { id, published: true, deletedAt: null },
       include: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -153,7 +153,7 @@ async function FeaturedDesigners() {
 async function StatsRow() {
   let total = 0, venues = 0, byType: unknown[] = []
   try {
-    ;[total, venues, byType] = await Promise.all([
+    ;[total, venues, byType] = await prisma.$transaction([
       prisma.estate.count({ where: { published: true, deletedAt: null } }),
       prisma.estate.count({ where: { published: true, type: "VENUE", deletedAt: null } }),
       prisma.estate.groupBy({

--- a/src/app/submit/page.tsx
+++ b/src/app/submit/page.tsx
@@ -13,7 +13,7 @@ export default async function SubmitPage() {
   const session = await auth()
   if (!session?.user?.id) redirect("/login")
 
-  const [dbUser, rawCharacters] = await Promise.all([
+  const [dbUser, rawCharacters] = await prisma.$transaction([
     prisma.user.findUnique({
       where: { id: session.user.id },
       select: { designer: true },


### PR DESCRIPTION
## Problem

`MaxClientsInSessionMode` was still occurring on estate submit, estate detail, estate edit, directory listing, and homepage stats — all pages that still had `Promise.all([prisma...])` which were missed in PR #175.

## Fix

Convert all remaining parallel Prisma queries to `prisma.$transaction([...])`:

| File | Queries |
|------|---------|
| `src/app/submit/page.tsx` | `dbUser` + `rawCharacters` |
| `src/app/directory/page.tsx` | `findMany` + `count` |
| `src/app/estate/[id]/page.tsx` | `estate` + `comments` |
| `src/app/estate/[id]/edit/page.tsx` | `estate` + `rawCharacters` |
| `src/app/page.tsx` (StatsRow) | 3 count queries |

🤖 Generated with [Claude Code](https://claude.com/claude-code)