### PR TITLE
release: last updated date on estate cards and updated-within filter

### DIFF
--- a/src/app/character/[characterId]/page.tsx
+++ b/src/app/character/[characterId]/page.tsx
@@ -111,6 +111,7 @@ export default async function CharacterProfilePage({ params }: PageProps) {
               ownerName={character.characterName}
               lodestoneVerified={character.verified}
               venueType={estate.venueDetails?.venueType ?? null}
+              updatedAt={estate.updatedAt}
             />
           ))}
         </div>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -333,6 +333,7 @@ export default async function DashboardPage() {
                   lodestoneVerified={!!verifiedChar}
                   venueType={estate.venueDetails?.venueType ?? null}
                   published={estate.published}
+                  updatedAt={estate.updatedAt}
                 />
               )
             })}

--- a/src/app/directory/directory-filters.tsx
+++ b/src/app/directory/directory-filters.tsx
@@ -25,11 +25,12 @@ interface Props {
   estateTypes: readonly { value: string; label: string }[]
   districts: readonly { value: string; label: string }[]
   tags: readonly string[]
+  updatedSince?: string
 }
 
 const EMPTY = "__all__"
 
-export function DirectoryFilters({ regions, estateTypes, districts, tags }: Props) {
+export function DirectoryFilters({ regions, estateTypes, districts, tags, updatedSince }: Props) {
   const router = useRouter()
   const searchParams = useSearchParams()
 
@@ -65,7 +66,8 @@ export function DirectoryFilters({ regions, estateTypes, districts, tags }: Prop
     searchParams.get("type") ||
     searchParams.get("district") ||
     searchParams.get("tags") ||
-    searchParams.get("q")
+    searchParams.get("q") ||
+    searchParams.get("updatedSince")
 
   return (
     <div className="space-y-5">
@@ -109,6 +111,27 @@ export function DirectoryFilters({ regions, estateTypes, districts, tags }: Prop
             <SelectItem value="newest">Newest</SelectItem>
             <SelectItem value="likes">Most Liked</SelectItem>
             <SelectItem value="updated">Recently Updated</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <Separator />
+
+      <div>
+        <Label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Updated Within</Label>
+        <Select
+          value={updatedSince ?? EMPTY}
+          onValueChange={(v) => update("updatedSince", v === EMPTY ? null : v)}
+        >
+          <SelectTrigger className="mt-1">
+            <SelectValue placeholder="Any time" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={EMPTY}>Any time</SelectItem>
+            <SelectItem value="7d">Last 7 days</SelectItem>
+            <SelectItem value="30d">Last 30 days</SelectItem>
+            <SelectItem value="90d">Last 90 days</SelectItem>
+            <SelectItem value="1y">Last year</SelectItem>
           </SelectContent>
         </Select>
       </div>

--- a/src/app/directory/page.tsx
+++ b/src/app/directory/page.tsx
@@ -7,6 +7,13 @@ import { REGIONS, ESTATE_TYPES, HOUSING_DISTRICTS, PREDEFINED_TAGS } from "@/lib
 
 export const metadata: Metadata = { title: "Browse Estates" }
 
+const UPDATED_SINCE_DAYS: Record<string, number> = {
+  "7d": 7,
+  "30d": 30,
+  "90d": 90,
+  "1y": 365,
+}
+
 interface DirectoryPageProps {
   searchParams: Promise<{
     region?: string
@@ -18,6 +25,7 @@ interface DirectoryPageProps {
     q?: string
     sort?: string
     page?: string
+    updatedSince?: string
   }>
 }
 
@@ -29,6 +37,13 @@ export default async function DirectoryPage({ searchParams }: DirectoryPageProps
   const sort = params.sort ?? "newest"
   const selectedTags = params.tags ? params.tags.split(",").filter(Boolean) : []
 
+  const updatedSinceDays = params.updatedSince ? UPDATED_SINCE_DAYS[params.updatedSince] : undefined
+  // eslint-disable-next-line react-hooks/purity
+  const nowMs = Date.now()
+  const updatedSinceDate = updatedSinceDays
+    ? new Date(nowMs - updatedSinceDays * 24 * 60 * 60 * 1000)
+    : undefined
+
   const where = {
     published: true,
     deletedAt: null,
@@ -38,6 +53,7 @@ export default async function DirectoryPage({ searchParams }: DirectoryPageProps
     ...(params.type ? { type: params.type as never } : {}),
     ...(params.district ? { district: params.district as never } : {}),
     ...(selectedTags.length > 0 ? { tags: { hasSome: selectedTags } } : {}),
+    ...(updatedSinceDate ? { updatedAt: { gte: updatedSinceDate } } : {}),
     ...(params.q
       ? {
           OR: [
@@ -70,6 +86,7 @@ export default async function DirectoryPage({ searchParams }: DirectoryPageProps
         dataCenter: true,
         tags: true,
         likeCount: true,
+        updatedAt: true,
         images: { orderBy: { order: "asc" }, take: 1, select: { imageUrl: true } },
         owner: {
           select: {
@@ -107,6 +124,7 @@ export default async function DirectoryPage({ searchParams }: DirectoryPageProps
               estateTypes={ESTATE_TYPES}
               districts={HOUSING_DISTRICTS}
               tags={PREDEFINED_TAGS}
+              updatedSince={params.updatedSince}
             />
           </Suspense>
         </aside>
@@ -138,6 +156,7 @@ export default async function DirectoryPage({ searchParams }: DirectoryPageProps
                       ownerName={ownerName ?? null}
                       lodestoneVerified={!!verifiedChar}
                       venueType={estate.venueDetails?.venueType ?? null}
+                      updatedAt={estate.updatedAt}
                     />
                   )
                 })}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -66,6 +66,7 @@ async function FeaturedEstates() {
               ownerName={ownerName ?? null}
               lodestoneVerified={!!verifiedChar}
               venueType={estate.venueDetails?.venueType ?? null}
+              updatedAt={estate.updatedAt}
             />
           )
         })}

--- a/src/app/profile/[userId]/collections/[collectionId]/page.tsx
+++ b/src/app/profile/[userId]/collections/[collectionId]/page.tsx
@@ -109,6 +109,7 @@ export default async function CollectionDetailPage({ params }: PageProps) {
                 ownerName={estateOwnerName ?? null}
                 lodestoneVerified={!!verifiedChar}
                 venueType={estate.venueDetails?.venueType ?? null}
+                updatedAt={estate.updatedAt}
               />
             )
           })}

--- a/src/app/profile/[userId]/page.tsx
+++ b/src/app/profile/[userId]/page.tsx
@@ -151,6 +151,7 @@ export default async function ProfilePage({ params }: PageProps) {
               ownerName={displayName}
               lodestoneVerified={isVerified}
               venueType={pinnedEstate.venueDetails?.venueType ?? null}
+              updatedAt={pinnedEstate.updatedAt}
             />
           </div>
         </div>
@@ -175,6 +176,7 @@ export default async function ProfilePage({ params }: PageProps) {
               ownerName={displayName}
               lodestoneVerified={isVerified}
               venueType={estate.venueDetails?.venueType ?? null}
+              updatedAt={estate.updatedAt}
             />
           ))}
         </div>

--- a/src/components/estate-card.tsx
+++ b/src/components/estate-card.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link"
 import Image from "next/image"
-import { Heart, MapPin, BadgeCheck, Palette } from "lucide-react"
+import { Heart, MapPin, BadgeCheck, Palette, Clock } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { ESTATE_TYPES, HOUSING_DISTRICTS } from "@/lib/ffxiv-data"
 
@@ -21,6 +21,18 @@ interface EstateCardProps {
   published?: boolean
   designerName?: string | null
   claimedAt?: Date | null
+  updatedAt?: Date | null
+}
+
+function formatUpdatedAt(date: Date): string {
+  const now = Date.now()
+  const diff = now - date.getTime()
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24))
+  if (days === 0) return "Updated today"
+  if (days === 1) return "Updated yesterday"
+  if (days < 30) return `Updated ${days}d ago`
+  if (days < 365) return `Updated ${date.toLocaleDateString("en-US", { month: "short", day: "numeric" })}`
+  return `Updated ${date.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}`
 }
 
 export function EstateCard({
@@ -39,6 +51,7 @@ export function EstateCard({
   published = true,
   designerName,
   claimedAt,
+  updatedAt,
 }: EstateCardProps) {
   const typeLabel = ESTATE_TYPES.find((t) => t.value === type)?.label ?? type
   const districtLabel = HOUSING_DISTRICTS.find((d) => d.value === district)?.label
@@ -122,10 +135,18 @@ export function EstateCard({
               </span>
             )}
           </div>
-          <span className="flex items-center gap-1 text-xs text-muted-foreground ml-auto shrink-0">
-            <Heart className="h-3 w-3" />
-            {likeCount}
-          </span>
+          <div className="flex items-center gap-2 ml-auto shrink-0">
+            {updatedAt && (
+              <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                <Clock className="h-3 w-3" />
+                {formatUpdatedAt(updatedAt)}
+              </span>
+            )}
+            <span className="flex items-center gap-1 text-xs text-muted-foreground">
+              <Heart className="h-3 w-3" />
+              {likeCount}
+            </span>
+          </div>
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary

Releases the last-updated date feature from develop to production.

- Estate cards now display a relative "Updated" timestamp (e.g., "Updated today", "Updated 3d ago", "Updated Jan 15") across all pages — homepage, directory, profile, dashboard, character, and collections
- New **Updated Within** filter in the directory sidebar: Any time / Last 7 days / Last 30 days / Last 90 days / Last year

## PRs included
- #173 — feat: add last updated date to estate cards and updated-within filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)