### PR TITLE
fix: prevent designer flag from bypassing verification on standard estate submission

### DIFF
--- a/src/app/api/estates/route.ts
+++ b/src/app/api/estates/route.ts
@@ -16,8 +16,8 @@ export async function POST(req: Request) {
 
   const body = await req.json()
 
-  // Designer submission path
-  if (body.designerSubmission) {
+  // Designer submission path — only if explicitly flagged AND no characterId (standard form always includes characterId)
+  if (body.designerSubmission === true && !body.characterId) {
     const dbUser = await prisma.user.findUnique({
       where: { id: session.user.id },
       select: { designer: true },

--- a/src/app/submit/estate-submit-form.tsx
+++ b/src/app/submit/estate-submit-form.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { useForm, useFieldArray } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
@@ -59,6 +59,11 @@ export function EstateSubmitForm({ characters, estateId, defaultValues, isDesign
   const [pendingDesignerValues, setPendingDesignerValues] = useState<DesignerEstateFormValues | null>(null)
   const isEditing = !!estateId
   const useDesignerFlow = isDesigner && designerMode && !isEditing
+
+  // Reset designer mode on mount to prevent stale state from soft navigation
+  useEffect(() => {
+    setDesignerMode(false)
+  }, [])
 
   const form = useForm<EstateFormInput, unknown, EstateFormValues>({
     resolver: zodResolver(estateFormSchema),


### PR DESCRIPTION
## Summary
- **API**: `if (body.designerSubmission)` changed to `if (body.designerSubmission === true && !body.characterId)` — standard form submissions always include `characterId`, so they can never accidentally take the designer path (which creates with `published: true`)
- **UI**: Added `useEffect` to reset `designerMode` to `false` on component mount, guarding against stale React state from soft navigation causing the designer form to be active unexpectedly

## Root cause
When a user with `designer = true` is on the submit page, a previous navigation to that page (soft nav) could leave `designerMode = true` in React state. If the user then submitted without noticing the designer banner, the estate would be created as `published: true` without verification. The API fix ensures standard form data (with `characterId`) always routes to the standard path regardless.

## Test plan
- [ ] With `designer = true`, navigate to `/submit`, confirm `designerMode` resets to standard on each visit
- [ ] Submit a standard estate — confirm it lands in dashboard as a Draft requiring verification
- [ ] Submit via designer mode — confirm it still publishes immediately as intended
- [ ] `pnpm tsc --noEmit` passes

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)