### PR TITLE
chore(release): develop → main

### DIFF
--- a/src/app/api/estates/route.ts
+++ b/src/app/api/estates/route.ts
@@ -16,8 +16,8 @@ export async function POST(req: Request) {
 
   const body = await req.json()
 
-  // Designer submission path
-  if (body.designerSubmission) {
+  // Designer submission path — only if explicitly flagged AND no characterId (standard form always includes characterId)
+  if (body.designerSubmission === true && !body.characterId) {
     const dbUser = await prisma.user.findUnique({
       where: { id: session.user.id },
       select: { designer: true },

--- a/src/app/submit/estate-submit-form.tsx
+++ b/src/app/submit/estate-submit-form.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { useForm, useFieldArray } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
@@ -59,6 +59,11 @@ export function EstateSubmitForm({ characters, estateId, defaultValues, isDesign
   const [pendingDesignerValues, setPendingDesignerValues] = useState<DesignerEstateFormValues | null>(null)
   const isEditing = !!estateId
   const useDesignerFlow = isDesigner && designerMode && !isEditing
+
+  // Reset designer mode on mount to prevent stale state from soft navigation
+  useEffect(() => {
+    setDesignerMode(false)
+  }, [])
 
   const form = useForm<EstateFormInput, unknown, EstateFormValues>({
     resolver: zodResolver(estateFormSchema),


### PR DESCRIPTION
## Release

Merges `develop` into `main` to trigger a semantic-release.

### Changes since last release
- **fix**: prevent designer flag from bypassing verification on standard estate submission (#188)

🤖 Generated with [Claude Code](https://claude.com/claude-code)