### PR TITLE
fix: suppress hydration warning on comment timestamps

### DIFF
--- a/src/components/comments-section.tsx
+++ b/src/components/comments-section.tsx
@@ -115,7 +115,7 @@ export function CommentsSection({ estateId, initialComments, isLoggedIn }: Comme
                     <Link href={`/profile/${comment.user.id}`} className="hover:underline">
                       {displayName}
                     </Link>
-                    <span className="text-xs text-muted-foreground font-normal ml-1">
+                    <span className="text-xs text-muted-foreground font-normal ml-1" suppressHydrationWarning>
                       {formatDistanceToNow(new Date(comment.createdAt), { addSuffix: true })}
                     </span>
                   </div>


### PR DESCRIPTION
## Summary

- Adds `suppressHydrationWarning` to the timestamp `<span>` in `CommentsSection`
- `formatDistanceToNow` produces different output on server vs. client (time elapses between SSR and hydration), causing a hydration mismatch on estate detail pages

**Sentry:** EORZEA-ESTATES-8

## Test plan

- [ ] Visit an estate detail page with comments and confirm no hydration error in the console
- [ ] Verify timestamps render correctly in both light and dark mode
- [ ] Confirm Sentry issue EORZEA-ESTATES-8 stops receiving new events after deploy

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)