### PR TITLE
fix: sync Discord avatar on sign-in and add broken image fallback

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link"
 import { UserRoleSelect } from "./user-role-select"
 import { PathfinderToggle } from "./pathfinder-toggle"
 import { DesignerToggle } from "./designer-toggle"
+import { UserAvatar } from "@/components/user-avatar"
 import { PATHFINDER_LIMIT } from "@/lib/pathfinder"
 import type { UserRole } from "@/types/roles"
 
@@ -68,19 +69,7 @@ export default async function AdminUsersPage() {
               <tr key={user.id} className="hover:bg-muted/30 transition-colors">
                 <td className="px-4 py-3">
                   <div className="flex items-center gap-3">
-                    {user.image ? (
-                      <Image
-                        src={user.image}
-                        alt={user.name ?? "User"}
-                        width={32}
-                        height={32}
-                        className="rounded-full shrink-0"
-                      />
-                    ) : (
-                      <div className="h-8 w-8 rounded-full bg-muted flex items-center justify-center shrink-0 text-xs font-bold">
-                        {user.name?.charAt(0).toUpperCase() ?? "?"}
-                      </div>
-                    )}
+                    <UserAvatar src={user.image} name={user.name} size={32} />
                     <div>
                       <Link href={`/profile/${user.id}`} className="brand-link font-medium">
                         {user.name ?? user.email ?? "Unknown"}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -25,7 +25,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   ],
   adapter: PrismaAdapter(prisma),
   callbacks: {
-    async signIn({ user, account }) {
+    async signIn({ user, account, profile }) {
       // Google and Discord both guarantee the email is verified.
       // Ensure emailVerified is set in the DB so password linking works correctly.
       if (account?.type === "oauth" && user.id) {
@@ -33,6 +33,27 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           where: { id: user.id, emailVerified: null },
           data: { emailVerified: new Date() },
         })
+
+        // Sync Discord avatar on every sign-in so stale CDN URLs don't break.
+        // Skip if the user has a verified Lodestone character (that image takes priority).
+        if (account.provider === "discord" && profile) {
+          const p = profile as { id?: string; avatar?: string | null }
+          const freshImage = p.id && p.avatar
+            ? `https://cdn.discordapp.com/avatars/${p.id}/${p.avatar}.png`
+            : null
+          if (freshImage) {
+            const hasLodestone = await prisma.ffxivCharacter.findFirst({
+              where: { userId: user.id, verified: true },
+              select: { id: true },
+            })
+            if (!hasLodestone) {
+              await prisma.user.update({
+                where: { id: user.id },
+                data: { image: freshImage },
+              })
+            }
+          }
+        }
       }
       return true
     },

--- a/src/components/user-avatar.tsx
+++ b/src/components/user-avatar.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { useState } from "react"
+import Image from "next/image"
+
+interface Props {
+  src: string | null | undefined
+  name: string | null | undefined
+  size?: number
+  className?: string
+}
+
+export function UserAvatar({ src, name, size = 32, className = "" }: Props) {
+  const [error, setError] = useState(false)
+
+  if (src && !error) {
+    return (
+      <Image
+        src={src}
+        alt={name ?? "User"}
+        width={size}
+        height={size}
+        className={`rounded-full shrink-0 ${className}`}
+        onError={() => setError(true)}
+      />
+    )
+  }
+
+  return (
+    <div
+      className={`rounded-full bg-muted flex items-center justify-center shrink-0 text-xs font-bold ${className}`}
+      style={{ width: size, height: size }}
+    >
+      {name?.charAt(0).toUpperCase() ?? "?"}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- On every Discord sign-in, updates `User.image` from the fresh OAuth profile so stale CDN URLs caused by avatar changes are corrected automatically (skipped if user has a verified Lodestone character, which takes priority)
- New `UserAvatar` client component with `onError` fallback to initials, preventing broken image icons for any URLs that haven't been refreshed yet
- Admin users page now uses `UserAvatar`

Closes #209

## Test plan
- [ ] Change Discord avatar → sign out → sign back in → avatar updates in admin panel and navbar
- [ ] User with a stale/broken Discord avatar URL shows initials fallback instead of broken image icon
- [ ] User with a verified Lodestone character: Discord sign-in does not overwrite their Lodestone avatar

🤖 Generated with [Claude Code](https://claude.com/claude-code)