### PR TITLE
perf: prioritize above-fold images to improve LCP on home and directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,6 @@ DIRECT_URL            # Supabase direct connection (required for migrations)
 AUTH_SECRET           # NextAuth secret (generate with: openssl rand -base64 32)
 AUTH_DISCORD_ID       # Discord OAuth client ID
 AUTH_DISCORD_SECRET   # Discord OAuth client secret
-CLOUDINARY_CLOUD_NAME
-CLOUDINARY_API_KEY
-CLOUDINARY_API_SECRET
 NEXTAUTH_URL          # http://localhost:3000 (dev) or production domain
 ```
 
@@ -50,7 +47,7 @@ NEXTAUTH_URL          # http://localhost:3000 (dev) or production domain
 - **Next.js 16** with App Router, React 19, TypeScript
 - **Auth**: NextAuth v5 (beta) with Discord OAuth, JWT sessions, Prisma adapter
 - **Database**: PostgreSQL via Supabase, accessed with Prisma 7 (client generated to `src/generated/prisma/`)
-- **Images**: Cloudinary (server-side signed uploads)
+- **Images**: Supabase Storage, served via `*.supabase.co`
 - **UI**: Tailwind CSS v4, shadcn/ui components (`src/components/ui/`), Radix UI
 - **Forms**: react-hook-form + Zod validation
 - **Testing**: Vitest (unit/component), Playwright (E2E)
@@ -76,7 +73,7 @@ NEXTAUTH_URL          # http://localhost:3000 (dev) or production domain
 - `estates/` — create estates; `estates/[id]` — read/update/delete
 - `comments/[estateId]` — list/post comments
 - `likes/[estateId]` — toggle like
-- `upload` — Cloudinary signed upload
+- `upload` — image upload
 - `lodestone/start` + `lodestone/confirm` — character verification
 - `characters/` + `characters/[id]` — character management
 - `characters/[id]/reverify-fc` — re-verification flow for FC-related estates

--- a/next.config.ts
+++ b/next.config.ts
@@ -20,7 +20,7 @@ const nextConfig: NextConfig = {
       {
         protocol: "https",
         hostname: "*.supabase.co",
-      }
+      },
     ],
   },
 };

--- a/src/app/directory/page.tsx
+++ b/src/app/directory/page.tsx
@@ -153,7 +153,7 @@ export default async function DirectoryPage({ searchParams }: DirectoryPageProps
           ) : (
             <>
               <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
-                {estates.map((estate) => {
+                {estates.map((estate, i) => {
                   const verifiedChar = estate.owner.characters[0]
                   const ownerName = verifiedChar?.characterName ?? estate.owner.name
                   return (
@@ -168,6 +168,7 @@ export default async function DirectoryPage({ searchParams }: DirectoryPageProps
                       tags={estate.tags}
                       likeCount={estate.likeCount}
                       coverImage={estate.images[0]?.imageUrl}
+                      priority={i < 3}
                       ownerName={ownerName ?? null}
                       lodestoneVerified={!!verifiedChar}
                       venueType={estate.venueDetails?.venueType ?? null}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -48,7 +48,7 @@ async function FeaturedEstates() {
         </Button>
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {estates.map((estate) => {
+        {estates.map((estate, i) => {
           const verifiedChar = estate.owner.characters[0]
           const ownerName = verifiedChar?.characterName ?? estate.owner.name
           return (
@@ -63,6 +63,7 @@ async function FeaturedEstates() {
               tags={estate.tags}
               likeCount={estate.likeCount}
               coverImage={estate.images[0]?.imageUrl}
+              priority={i < 3}
               ownerName={ownerName ?? null}
               lodestoneVerified={!!verifiedChar}
               venueType={estate.venueDetails?.venueType ?? null}

--- a/src/components/estate-card.tsx
+++ b/src/components/estate-card.tsx
@@ -15,6 +15,7 @@ interface EstateCardProps {
   tags: string[]
   likeCount: number
   coverImage?: string | null
+  priority?: boolean
   ownerName?: string | null
   ownerImage?: string | null
   lodestoneVerified?: boolean
@@ -47,6 +48,7 @@ export function EstateCard({
   tags,
   likeCount,
   coverImage,
+  priority = false,
   ownerName,
   lodestoneVerified,
   venueType,
@@ -69,6 +71,7 @@ export function EstateCard({
             src={coverImage}
             alt={name}
             fill
+            priority={priority}
             className={`object-cover${published ? " group-hover:scale-105 transition-transform duration-300" : ""}`}
             sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
           />

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -23,7 +23,7 @@ export default async function Navbar() {
       <header className="sticky top-0 z-50 w-full border-b bg-background">
         <div className="container mx-auto flex h-16 items-center justify-between px-4">
           <Link href="/" aria-label="Eorzea Estates home">
-            <Image src="/images/logo/eorzea-estates-navbar.svg" alt="Eorzea Estates" width={0} height={0} className="h-12 w-auto" />
+            <Image src="/images/logo/eorzea-estates-navbar.svg" alt="Eorzea Estates" width={156} height={48} priority className="h-12 w-auto" />
           </Link>
 
           <nav className="flex items-center gap-4">


### PR DESCRIPTION
## Summary

- `EstateCard` now accepts a `priority` prop passed to `next/image` — lazy by default, opt-in for above-fold cards
- Home page and directory page pass `priority={i < 3}` so the first row of estate cards is preloaded by the browser
- Navbar logo had `width={0} height={0}` preventing intrinsic size hints; fixed to `width={156} height={48}` with `priority` added since it's always above the fold
- Removed stale Cloudinary references from `CLAUDE.md` (images are served from Supabase Storage)

## Why this helps

FCP/LCP were 3.4s / 4.04s despite a healthy TTFB of 0.27s — the server was fast but the browser was discovering above-fold images too late. Adding `priority` injects a `<link rel="preload">` in `<head>` so the first row of estate images fetches in parallel with HTML parsing instead of after layout completes.

## Test plan

- [ ] Home page: first 3 estate card images should have `fetchpriority="high"` in rendered HTML
- [ ] Directory page: same for first 3 cards; remaining cards should not have it
- [ ] Navbar logo: inspect element shows `width="156" height="48"` (not 0)
- [ ] CI passes

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)