### PR TITLE
fix: make admin panel layout responsive on mobile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ prod.dump
 # Misc scripts
 sync_prod_to_develop.sh
 .env*.local
+credentials.txt

--- a/src/app/admin/admin-nav-link.tsx
+++ b/src/app/admin/admin-nav-link.tsx
@@ -15,7 +15,7 @@ export function AdminNavLink({ href, children }: Props) {
   return (
     <Link
       href={href}
-      className={`flex items-center gap-2 px-3 py-2 rounded-lg transition-colors ${
+      className={`flex shrink-0 items-center gap-2 px-3 py-2 rounded-lg transition-colors ${
         isActive
           ? "bg-accent text-accent-foreground font-medium"
           : "hover:bg-accent hover:text-accent-foreground text-muted-foreground"

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -11,14 +11,14 @@ export default async function AdminLayout({ children }: { children: React.ReactN
   const isAdmin = role === "ADMIN"
 
   return (
-    <div className="flex min-h-[calc(100vh-4rem)]">
-      {/* Sidebar */}
-      <aside className="w-56 shrink-0 border-r px-3 py-6 flex flex-col gap-1">
-        <div className="flex items-center gap-2 px-3 mb-6">
+    <div className="flex flex-col md:flex-row min-h-[calc(100vh-4rem)]">
+      {/* Sidebar — collapses to horizontal top nav on mobile */}
+      <aside className="md:w-56 md:shrink-0 border-b md:border-b-0 md:border-r px-3 py-3 md:py-6 flex flex-col gap-1">
+        <div className="flex items-center gap-2 px-3 mb-3 md:mb-6">
           <ShieldCheck className="h-5 w-5 text-primary" />
           <span className="font-semibold text-sm">{isAdmin ? "Admin Panel" : "Mod Panel"}</span>
         </div>
-        <nav className="flex flex-col gap-1 text-sm">
+        <nav className="flex flex-row md:flex-col gap-1 text-sm overflow-x-auto pb-1 md:pb-0">
           {isAdmin && (
             <>
               <AdminNavLink href="/admin">
@@ -51,7 +51,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
       </aside>
 
       {/* Main content */}
-      <main className="flex-1 px-8 py-8 overflow-auto">
+      <main className="flex-1 px-4 md:px-8 py-6 md:py-8 overflow-auto">
         {children}
       </main>
     </div>

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -51,8 +51,8 @@ export default async function AdminUsersPage() {
         {atLimit && <span className="text-destructive text-xs">(limit reached)</span>}
       </div>
 
-      <div className="border rounded-xl overflow-hidden">
-        <table className="w-full text-sm">
+      <div className="border rounded-xl overflow-x-auto">
+        <table className="w-full text-sm min-w-[700px]">
           <thead className="bg-muted/50 border-b">
             <tr>
               <th className="text-left px-4 py-3 font-medium">User</th>


### PR DESCRIPTION
## Summary
- Collapses sidebar into a horizontally scrollable top nav on mobile (< `md` breakpoint); stacks layout vertically with nav above content
- Adds `shrink-0` to nav links so they don't compress when scrolling horizontally
- Adds `overflow-x-auto` and `min-w-[700px]` to the users table container so the wide table scrolls instead of clipping
- Reduces main content padding on mobile (`px-4 py-6` vs `px-8 py-8` on desktop)

## Test plan
- [ ] Open admin panel on a mobile-width viewport — sidebar should appear as a horizontal scrollable nav at the top
- [ ] All five nav items (Dashboard, Users & Roles, Moderation, Legal Pages, Settings) are accessible by scrolling the nav
- [ ] Main content takes full viewport width on mobile
- [ ] Users & Roles table scrolls horizontally on mobile without clipping
- [ ] Desktop layout unchanged — sidebar still appears on the left

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)