### PR TITLE
feat: add character and Lodestone profile links on admin users page

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -101,7 +101,7 @@ export default async function AdminUsersPage() {
                             />
                           )}
                           <span className="text-sm">
-                            <Link href={`/character/${char.id}`} target="_blank" className="brand-link">
+                            <Link href={`/character/${char.id}`} className="brand-link">
                               {char.characterName}
                             </Link>
                             {" "}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -27,7 +27,7 @@ export default async function AdminUsersPage() {
       designer: true,
       createdAt: true,
       _count: { select: { estates: true, characters: true } },
-      characters: { where: { verified: true }, select: { characterName: true, avatarUrl: true }, orderBy: { createdAt: "asc" } },
+      characters: { where: { verified: true }, select: { id: true, characterName: true, avatarUrl: true, lodestoneId: true }, orderBy: { createdAt: "asc" } },
       accounts: { select: { provider: true } },
     },
     orderBy: { createdAt: "asc" },
@@ -100,7 +100,20 @@ export default async function AdminUsersPage() {
                               className="rounded-full shrink-0"
                             />
                           )}
-                          <span className="text-sm">{char.characterName}</span>
+                          <span className="text-sm">
+                            <Link href={`/character/${char.id}`} target="_blank" className="brand-link">
+                              {char.characterName}
+                            </Link>
+                            {" "}
+                            <Link
+                              href={`https://na.finalfantasyxiv.com/lodestone/character/${char.lodestoneId}/`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                            >
+                              (Lodestone Profile)
+                            </Link>
+                          </span>
                         </div>
                       ))}
                     </div>


### PR DESCRIPTION
## Summary
- Character names on the admin Users & Roles page now link to the internal `/character/[id]` page 
- A secondary `(Lodestone Profile)` link is shown after each character name, linking to the Lodestone character page (opens in new tab)
- Added `id` and `lodestoneId` to the characters select query to support both links

## Test plan
- [ ] Open admin Users & Roles page
- [ ] For a user with verified characters, click the character name — should navigate to `/character/[id]` in a new tab
- [ ] Click `(Lodestone Profile)` — should open the Lodestone character page in a new tab
- [ ] Users with no verified characters still show `—` as before

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)