### PR TITLE
feat: add credential migration script for Better Auth

### DIFF
--- a/scripts/migrate-credentials-to-accounts.ts
+++ b/scripts/migrate-credentials-to-accounts.ts
@@ -1,0 +1,95 @@
+/**
+ * Phase 2 of NextAuth → Better Auth migration.
+ *
+ * Better Auth requires passwords to live in the Account table with
+ * providerId="credential" rather than on User.password.  This script
+ * copies existing bcrypt hashes from User.password into a credential
+ * Account row for every user that has a password set.
+ *
+ * Prerequisites:
+ *   - Phase 1 migration must already be deployed (adds accountId, providerId,
+ *     password columns to Account).
+ *
+ * Safety:
+ *   - Idempotent: skips users that already have a credential Account row.
+ *   - Does NOT clear User.password — NextAuth still reads it during the
+ *     dual-run period. User.password is dropped in Phase 5 cleanup.
+ *   - Run against a DB snapshot before running against production.
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/migrate-credentials-to-accounts.ts
+ */
+
+import prisma from "@/lib/prisma"
+
+async function run() {
+  // Find all users that have a password (credentials-based accounts)
+  const users = await prisma.$queryRaw<Array<{ id: string; password: string }>>`
+    SELECT id, password FROM "User" WHERE password IS NOT NULL
+  `
+
+  console.log(`Found ${users.length} user(s) with passwords`)
+
+  let created = 0
+  let skipped = 0
+
+  for (const user of users) {
+    // Check if a credential Account already exists for this user (idempotent)
+    const existing = await prisma.$queryRaw<Array<{ id: string }>>`
+      SELECT id FROM "Account"
+      WHERE "userId" = ${user.id}
+        AND "providerId" = 'credential'
+      LIMIT 1
+    `
+
+    if (existing.length > 0) {
+      console.log(`  [skip] User ${user.id} — credential Account already exists`)
+      skipped++
+      continue
+    }
+
+    // Better Auth uses userId as the accountId for credential accounts.
+    // The legacy NextAuth fields (provider, providerAccountId, type) are
+    // populated so the NOT NULL constraints on those columns are satisfied
+    // during the dual-run period.
+    await prisma.$executeRaw`
+      INSERT INTO "Account" (
+        id,
+        "userId",
+        "accountId",
+        "providerId",
+        password,
+        -- Legacy NextAuth fields (NOT NULL during dual-run period)
+        type,
+        provider,
+        "providerAccountId",
+        -- Timestamps
+        "createdAt",
+        "updatedAt"
+      ) VALUES (
+        gen_random_uuid()::text,
+        ${user.id},
+        ${user.id},
+        'credential',
+        ${user.password},
+        'credentials',
+        'credentials',
+        ${user.id},
+        now(),
+        now()
+      )
+    `
+
+    console.log(`  [ok]   Created credential Account for user ${user.id}`)
+    created++
+  }
+
+  console.log(`\nDone. Created: ${created}, Skipped (already existed): ${skipped}`)
+}
+
+run()
+  .catch((err) => {
+    console.error("Migration failed:", err)
+    process.exit(1)
+  })
+  .finally(() => prisma.$disconnect())


### PR DESCRIPTION
## Summary

- Adds `scripts/migrate-credentials-to-accounts.ts` — a one-time data migration script that copies bcrypt password hashes from `User.password` into `Account` rows with `providerId="credential"`, as required by Better Auth

## Details

Better Auth requires credentials (email/password auth) to be stored in the `Account` table rather than on the `User` model. This script bridges the gap for existing users.

- Idempotent — safe to run multiple times; skips users that already have a credential Account
- Does NOT clear `User.password` during dual-run period (NextAuth still reads it)
- Uses raw SQL for the Account insert to be independent of the Prisma generated client version
- Requires Phase 1 schema migration (#246) to be deployed first

**Run with:** `pnpm exec tsx scripts/migrate-credentials-to-accounts.ts`

## Test plan

- [ ] Run against a production DB snapshot first, verify output counts are correct
- [ ] Confirm users with passwords get exactly one `Account` row with `providerId="credential"`
- [ ] Confirm running a second time produces "skipped" for all rows (idempotent)
- [ ] All 53 unit tests pass

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)