### PR TITLE
fix: reduce DB connections exhausting PgBouncer session pool

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -6,6 +6,8 @@ function createPrismaClient() {
   const pool = new Pool({
     connectionString: process.env.DATABASE_URL!,
     max: 1,
+    idleTimeoutMillis: 10000,
+    connectionTimeoutMillis: 5000,
   })
   const adapter = new PrismaPg(pool)
   return new PrismaClient({ adapter })

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,8 +4,6 @@ import { auth } from "@/lib/auth"
 const protectedRoutes = ["/submit", "/dashboard", "/estate", "/messages"]
 
 export default async function middleware(req: NextRequest) {
-  const session = await auth.api.getSession({ headers: req.headers })
-
   const pathname = req.nextUrl.pathname
 
   // Pass pathname to server components via request header (used for maintenance check in root layout)
@@ -13,9 +11,22 @@ export default async function middleware(req: NextRequest) {
   requestHeaders.set("x-pathname", pathname)
   const next = () => NextResponse.next({ request: { headers: requestHeaders } })
 
+  const isProtected = protectedRoutes.some((route) => pathname.startsWith(route))
+  const isAdmin = pathname.startsWith("/admin")
+  const isMaintenanceActive =
+    process.env.MAINTENANCE_MODE === "true" ||
+    req.cookies.get("x-maintenance-mode")?.value === "1"
+
+  // Skip DB session lookup entirely for requests that don't need auth
+  if (!isProtected && !isAdmin && !isMaintenanceActive) {
+    // Allow GET to /estate/[id] (public detail page) without auth
+    return next()
+  }
+
+  const session = await auth.api.getSession({ headers: req.headers })
+
   // Maintenance mode: env var hard override OR DB toggle (signalled via cookie)
-  const dbMaintenanceCookie = req.cookies.get("x-maintenance-mode")?.value
-  if (process.env.MAINTENANCE_MODE === "true" || dbMaintenanceCookie === "1") {
+  if (isMaintenanceActive) {
     const allowedPaths = ["/maintenance", "/login", "/api/auth", "/api/maintenance-signout"]
     const isAllowed = allowedPaths.some((p) => pathname.startsWith(p))
     if (!isAllowed && session?.user?.role !== "ADMIN") {
@@ -25,10 +36,6 @@ export default async function middleware(req: NextRequest) {
       return NextResponse.redirect(new URL("/maintenance", req.nextUrl.origin))
     }
   }
-
-  const isProtected = protectedRoutes.some((route) =>
-    pathname.startsWith(route)
-  )
 
   // Allow GET to /estate/[id] (public detail page); only protect /estate/[id]/edit
   if (pathname.match(/^\/estate\/[^/]+$/) && req.method === "GET") {
@@ -42,7 +49,7 @@ export default async function middleware(req: NextRequest) {
   }
 
   // Admin routes require ADMIN role (moderation page also accessible to MODERATOR)
-  if (pathname.startsWith("/admin")) {
+  if (isAdmin) {
     if (!session) {
       const loginUrl = new URL("/login", req.nextUrl.origin)
       loginUrl.searchParams.set("callbackUrl", pathname)


### PR DESCRIPTION
## Summary

- Skip `auth.api.getSession()` in middleware for public routes — only call it when the route actually requires authentication (protected, admin, or maintenance mode active)
- Add `idleTimeoutMillis` and `connectionTimeoutMillis` to `pg.Pool` so Lambda instances release connections faster

## Root cause

Better Auth uses database sessions; the middleware was calling `auth.api.getSession()` on every request. With many concurrent Vercel Lambda instances each holding one PgBouncer connection, the session-mode pool was exhausted.

**Also required**: update `DATABASE_URL` in Vercel to use port `6543` (PgBouncer transaction mode) instead of `5432` (session mode).

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)