### PR TITLE
ci: auto-deploy CF Workers on release and develop sync

### DIFF
--- a/.github/workflows/deploy-cf-auto.yml
+++ b/.github/workflows/deploy-cf-auto.yml
@@ -1,0 +1,51 @@
+name: Auto Deploy to Cloudflare Workers
+
+on:
+  release:
+    types: [published]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  deploy-production:
+    name: Deploy to Cloudflare Workers (production)
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm prisma generate
+
+      - name: Run database migrations
+        run: pnpm prisma migrate deploy
+        env:
+          DIRECT_URL: ${{ secrets.DIRECT_URL }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
+      - name: Build
+        run: pnpm exec opennextjs-cloudflare build && node scripts/patch-cf-externals.mjs
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DIRECT_URL: ${{ secrets.DIRECT_URL }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Deploy
+        run: pnpm exec wrangler deploy --env production
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          OPEN_NEXT_DEPLOY: "true"

--- a/.github/workflows/deploy-cf-auto.yml
+++ b/.github/workflows/deploy-cf-auto.yml
@@ -49,3 +49,9 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           OPEN_NEXT_DEPLOY: "true"
+
+      - name: CF Dashboard logs link
+        if: always()
+        run: |
+          echo "### Cloudflare Worker Logs" >> $GITHUB_STEP_SUMMARY
+          echo "[View logs in CF Dashboard](https://dash.cloudflare.com/${{ vars.CLOUDFLARE_ACCOUNT_ID }}/workers/services/view/eorzea-estates/production/logs)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -3,6 +3,7 @@ name: Sync Main to Develop
 permissions:
   contents: write
   pull-requests: write
+  actions: read
 
 on:
   workflow_run:
@@ -113,3 +114,52 @@ jobs:
         if: failure()
         run: |
           echo "::error::Failed to sync main to develop. Check workflow logs for details."
+
+  deploy-preview:
+    name: Deploy to Cloudflare Workers (preview)
+    runs-on: ubuntu-latest
+    needs: sync
+    if: needs.sync.outputs.sync_status == 'success'
+    environment: preview
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: develop
+          token: ${{ secrets.SYNC_PAT }}
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm prisma generate
+
+      - name: Run database migrations
+        run: pnpm prisma migrate deploy
+        env:
+          DIRECT_URL: ${{ secrets.DIRECT_URL }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
+      - name: Build
+        run: pnpm exec opennextjs-cloudflare build && node scripts/patch-cf-externals.mjs
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DIRECT_URL: ${{ secrets.DIRECT_URL }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: Deploy
+        run: pnpm exec wrangler deploy --env preview
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          OPEN_NEXT_DEPLOY: "true"

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -163,3 +163,9 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           OPEN_NEXT_DEPLOY: "true"
+
+      - name: CF Dashboard logs link
+        if: always()
+        run: |
+          echo "### Cloudflare Worker Logs" >> $GITHUB_STEP_SUMMARY
+          echo "[View logs in CF Dashboard](https://dash.cloudflare.com/${{ vars.CLOUDFLARE_ACCOUNT_ID }}/workers/services/view/eorzea-estates-preview/production/logs)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- Add `deploy-cf-auto.yml` — triggers on `release: [published]` to auto-deploy CF production (fires exactly once per release, avoids the double-deploy Vercel caused from the semantic-release changelog commit)
- Extend `sync-develop.yml` — adds `deploy-preview` job after successful sync to redeploy CF preview and update the version in the footer

## Related
Part of #262 (Cloudflare Workers migration follow-up)

## Test plan
- [ ] Merge to `develop`, verify CI passes
- [ ] Merge `develop` → `main`, confirm `deploy-cf-auto.yml` fires on release publish
- [ ] Confirm `sync-develop.yml` `deploy-preview` job runs after back-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)