### PR TITLE
ci: fix deploy-cf-auto trigger (workflow_run instead of release event)

### DIFF
--- a/.github/workflows/deploy-cf-auto.yml
+++ b/.github/workflows/deploy-cf-auto.yml
@@ -1,8 +1,11 @@
 name: Auto Deploy to Cloudflare Workers
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -11,6 +14,7 @@ jobs:
   deploy-production:
     name: Deploy to Cloudflare Workers (production)
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     environment: production
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- `release: [published]` never fires when the release is created by `GITHUB_TOKEN` (GitHub blocks it to prevent infinite loops)
- Switch to `workflow_run` on the Release workflow completing successfully — same pattern already used in `sync-develop.yml`
- Also adds `workflow_dispatch` for manual re-deploys

Part of #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)