### PR TITLE
ci: fix CF production auto-deploy trigger

### DIFF
--- a/.github/workflows/deploy-cf-auto.yml
+++ b/.github/workflows/deploy-cf-auto.yml
@@ -1,8 +1,11 @@
 name: Auto Deploy to Cloudflare Workers
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -11,6 +14,7 @@ jobs:
   deploy-production:
     name: Deploy to Cloudflare Workers (production)
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     environment: production
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- `release: [published]` never fires when `GITHUB_TOKEN` creates the release (GitHub blocks it to prevent infinite loops) — CF production was never being deployed on release
- Switch `deploy-cf-auto.yml` to `workflow_run` on the Release workflow completing, same pattern as `sync-develop.yml`

Closes #262

## Test plan
- [ ] CI passes
- [ ] Merge to `main` → Release workflow runs → `deploy-cf-auto.yml` fires → CF production deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)