### PR TITLE
fix: force-static on changelog page (fs.readFileSync not available in CF Workers)

### DIFF
--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -4,6 +4,8 @@ import { Metadata } from "next"
 import { BackButton } from "@/components/back-button"
 import { ChangelogRenderer } from "@/components/changelog-renderer"
 
+export const dynamic = "force-static"
+
 export const metadata: Metadata = { title: "Changelog" }
 
 export default function ChangelogPage() {


### PR DESCRIPTION
## Summary

- `readFileSync` on the changelog page was called at runtime in CF Workers, which stubs `fs` without implementing `readFileSync`
- Adding `export const dynamic = "force-static"` ensures the page is rendered at build time in Node.js where `fs` is available; CF Workers serves the pre-rendered HTML

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)