### PR TITLE
fix: inline CHANGELOG.md at build time via webpack (no runtime fs.readFileSync)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,10 @@ initOpenNextCloudflareForDev().catch((e: unknown) => {
 });
 
 const nextConfig: NextConfig = {
+  webpack(config) {
+    config.module.rules.push({ test: /\.md$/, type: "asset/source" })
+    return config
+  },
   serverExternalPackages: ["@xivapi/nodestone", "regex-translator", "@langfuse/otel", "@opentelemetry/sdk-node"],
   // Turbopack hashes sharp to a random module ID (e.g. "sharp-03c9e6d01f648d5d") that
   // OpenNext's esbuild step cannot resolve. Aliasing to a null shim prevents the error.

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -1,21 +1,18 @@
-import { readFileSync } from "fs"
-import { join } from "path"
 import { Metadata } from "next"
 import { BackButton } from "@/components/back-button"
 import { ChangelogRenderer } from "@/components/changelog-renderer"
+import raw from "../../../../CHANGELOG.md"
 
 export const dynamic = "force-static"
 
 export const metadata: Metadata = { title: "Changelog" }
 
 export default function ChangelogPage() {
-  const raw = readFileSync(join(process.cwd(), "CHANGELOG.md"), "utf-8")
-
   return (
     <div className="max-w-2xl mx-auto px-4 py-12">
       <BackButton />
       <h1 className="text-2xl font-bold mb-8">Changelog</h1>
-      <ChangelogRenderer content={raw} />
+      <ChangelogRenderer content={raw as string} />
     </div>
   )
 }

--- a/src/types/markdown.d.ts
+++ b/src/types/markdown.d.ts
@@ -1,0 +1,4 @@
+declare module "*.md" {
+  const content: string
+  export default content
+}


### PR DESCRIPTION
## Summary

`force-static` alone is not sufficient — OpenNext still renders RSC payloads server-side at request time, so `readFileSync` was still hitting CF Workers' unimplemented `fs` stub.

Fix: configure webpack to treat `.md` files as `asset/source` (inlines content as a string literal at build time), then replace the `readFileSync` call with a static `import`. The file content is bundled into the worker at build time — no filesystem access at runtime.

Also adds `src/types/markdown.d.ts` so TypeScript accepts `import ... from "*.md"`.

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)