### PR TITLE
fix: embed CHANGELOG.md content at build time via next.config.ts env var

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,8 @@
 import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";
+import { readFileSync } from "fs";
+import { join } from "path";
 
 // Don't crash the build if local Hyperdrive proxy fails to start (e.g., no
 // localConnectionString configured). Wrangler sets up the CF context at
@@ -11,10 +13,11 @@ initOpenNextCloudflareForDev().catch((e: unknown) => {
   }
 });
 
+const changelogContent = readFileSync(join(process.cwd(), "CHANGELOG.md"), "utf-8");
+
 const nextConfig: NextConfig = {
-  webpack(config) {
-    config.module.rules.push({ test: /\.md$/, type: "asset/source" })
-    return config
+  env: {
+    CHANGELOG_CONTENT: changelogContent,
   },
   serverExternalPackages: ["@xivapi/nodestone", "regex-translator", "@langfuse/otel", "@opentelemetry/sdk-node"],
   // Turbopack hashes sharp to a random module ID (e.g. "sharp-03c9e6d01f648d5d") that

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -1,7 +1,6 @@
 import { Metadata } from "next"
 import { BackButton } from "@/components/back-button"
 import { ChangelogRenderer } from "@/components/changelog-renderer"
-import raw from "../../../../CHANGELOG.md"
 
 export const dynamic = "force-static"
 
@@ -12,7 +11,7 @@ export default function ChangelogPage() {
     <div className="max-w-2xl mx-auto px-4 py-12">
       <BackButton />
       <h1 className="text-2xl font-bold mb-8">Changelog</h1>
-      <ChangelogRenderer content={raw as string} />
+      <ChangelogRenderer content={process.env.CHANGELOG_CONTENT ?? ""} />
     </div>
   )
 }

--- a/src/types/markdown.d.ts
+++ b/src/types/markdown.d.ts
@@ -1,4 +1,0 @@
-declare module "*.md" {
-  const content: string
-  export default content
-}


### PR DESCRIPTION
## Summary

Previous attempt (webpack `asset/source` rule) failed — Turbopack doesn't use webpack module rules, and the relative path `../../../../CHANGELOG.md` is outside Turbopack's allowed boundary.

This approach has no loader dependency: `next.config.ts` reads `CHANGELOG.md` with `readFileSync` at config-evaluation time (Node.js, build-time only) and injects it as a `env.CHANGELOG_CONTENT` constant. Next.js/Turbopack replaces `process.env.CHANGELOG_CONTENT` with the string literal at build time — no filesystem access at runtime in CF Workers.

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)