### PR TITLE
fix: CF Workers runtime compatibility (AsyncLocalStorage, CHANGELOG.md)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,10 @@ initOpenNextCloudflareForDev().catch((e: unknown) => {
 });
 
 const nextConfig: NextConfig = {
+  webpack(config) {
+    config.module.rules.push({ test: /\.md$/, type: "asset/source" })
+    return config
+  },
   serverExternalPackages: ["@xivapi/nodestone", "regex-translator", "@langfuse/otel", "@opentelemetry/sdk-node"],
   // Turbopack hashes sharp to a random module ID (e.g. "sharp-03c9e6d01f648d5d") that
   // OpenNext's esbuild step cannot resolve. Aliasing to a null shim prevents the error.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,8 @@
 import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";
+import { readFileSync } from "fs";
+import { join } from "path";
 
 // Don't crash the build if local Hyperdrive proxy fails to start (e.g., no
 // localConnectionString configured). Wrangler sets up the CF context at
@@ -11,10 +13,11 @@ initOpenNextCloudflareForDev().catch((e: unknown) => {
   }
 });
 
+const changelogContent = readFileSync(join(process.cwd(), "CHANGELOG.md"), "utf-8");
+
 const nextConfig: NextConfig = {
-  webpack(config) {
-    config.module.rules.push({ test: /\.md$/, type: "asset/source" })
-    return config
+  env: {
+    CHANGELOG_CONTENT: changelogContent,
   },
   serverExternalPackages: ["@xivapi/nodestone", "regex-translator", "@langfuse/otel", "@opentelemetry/sdk-node"],
   // Turbopack hashes sharp to a random module ID (e.g. "sharp-03c9e6d01f648d5d") that

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -1,7 +1,6 @@
 import { Metadata } from "next"
 import { BackButton } from "@/components/back-button"
 import { ChangelogRenderer } from "@/components/changelog-renderer"
-import raw from "../../../../CHANGELOG.md"
 
 export const dynamic = "force-static"
 
@@ -12,7 +11,7 @@ export default function ChangelogPage() {
     <div className="max-w-2xl mx-auto px-4 py-12">
       <BackButton />
       <h1 className="text-2xl font-bold mb-8">Changelog</h1>
-      <ChangelogRenderer content={raw as string} />
+      <ChangelogRenderer content={process.env.CHANGELOG_CONTENT ?? ""} />
     </div>
   )
 }

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -1,21 +1,18 @@
-import { readFileSync } from "fs"
-import { join } from "path"
 import { Metadata } from "next"
 import { BackButton } from "@/components/back-button"
 import { ChangelogRenderer } from "@/components/changelog-renderer"
+import raw from "../../../../CHANGELOG.md"
 
 export const dynamic = "force-static"
 
 export const metadata: Metadata = { title: "Changelog" }
 
 export default function ChangelogPage() {
-  const raw = readFileSync(join(process.cwd(), "CHANGELOG.md"), "utf-8")
-
   return (
     <div className="max-w-2xl mx-auto px-4 py-12">
       <BackButton />
       <h1 className="text-2xl font-bold mb-8">Changelog</h1>
-      <ChangelogRenderer content={raw} />
+      <ChangelogRenderer content={raw as string} />
     </div>
   )
 }

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -4,6 +4,8 @@ import { Metadata } from "next"
 import { BackButton } from "@/components/back-button"
 import { ChangelogRenderer } from "@/components/changelog-renderer"
 
+export const dynamic = "force-static"
+
 export const metadata: Metadata = { title: "Changelog" }
 
 export default function ChangelogPage() {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -10,6 +10,14 @@
  *   const { data: session } = authClient.useSession()
  */
 
+// CF Workers supports `node:async_hooks` as a static import but not as a
+// dynamic import. better-auth uses dynamic import internally and falls back
+// to globalThis.AsyncLocalStorage. Assign it here so the fallback always works.
+import { AsyncLocalStorage } from "node:async_hooks"
+if (!("AsyncLocalStorage" in globalThis)) {
+  (globalThis as unknown as Record<string, unknown>).AsyncLocalStorage = AsyncLocalStorage
+}
+
 import { betterAuth } from "better-auth"
 import { prismaAdapter } from "better-auth/adapters/prisma"
 import prisma from "@/lib/prisma"

--- a/src/types/markdown.d.ts
+++ b/src/types/markdown.d.ts
@@ -1,0 +1,4 @@
+declare module "*.md" {
+  const content: string
+  export default content
+}

--- a/src/types/markdown.d.ts
+++ b/src/types/markdown.d.ts
@@ -1,4 +1,0 @@
-declare module "*.md" {
-  const content: string
-  export default content
-}

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,0 @@
-{
-  "buildCommand": "prisma migrate deploy && next build",
-  "crons": [
-    {
-      "path": "/api/cron/verify-fc-estates",
-      "schedule": "0 6 * * *"
-    }
-  ]
-}


### PR DESCRIPTION
## Summary

- Fix better-auth crashing in CF Workers: `@better-auth/core` uses dynamic `import("node:async_hooks")` which fails in CF Workers; assign `AsyncLocalStorage` to `globalThis` in `src/lib/auth.ts` so the fallback works
- Fix `/changelog` 500 error: `readFileSync` at runtime hits CF Workers' unimplemented `fs` stub; read `CHANGELOG.md` in `next.config.ts` at build time and embed as `process.env.CHANGELOG_CONTENT`

Closes #274
Closes #276

## Test plan
- [ ] CI passes
- [ ] `/api/auth/get-session` returns 200 in CF Workers preview
- [ ] `/changelog` renders without errors in CF Workers preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)