### PR TITLE
fix(deps): remove invalid packageManager option from renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "packageManager": "pnpm",
   "schedule": ["every weekend"],
   "commitMessagePrefix": "chore(deps):",
   "semanticCommits": "enabled",


### PR DESCRIPTION
## Summary

- Removes invalid `packageManager` field from `renovate.json` — not a valid Renovate config option
- Renovate auto-detects pnpm from `pnpm-lock.yaml`

Closes #278