### PR TITLE
fix: replace @xivapi/nodestone with fetch-based xivapi.com shim for CF Workers

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -19,14 +19,24 @@ const nextConfig: NextConfig = {
   env: {
     CHANGELOG_CONTENT: changelogContent,
   },
-  serverExternalPackages: ["@xivapi/nodestone", "regex-translator", "@langfuse/otel", "@opentelemetry/sdk-node"],
+  serverExternalPackages: ["regex-translator", "@langfuse/otel", "@opentelemetry/sdk-node"],
   // Turbopack hashes sharp to a random module ID (e.g. "sharp-03c9e6d01f648d5d") that
   // OpenNext's esbuild step cannot resolve. Aliasing to a null shim prevents the error.
   // Next.js skips image optimization when sharp is unavailable, which is fine for CF Workers.
   turbopack: {
     resolveAlias: {
       sharp: "./src/shims/sharp.js",
+      "@xivapi/nodestone": "./src/shims/xivapi-nodestone.js",
     },
+  },
+  webpack(config) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const path = require("path")
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@xivapi/nodestone": path.resolve(__dirname, "src/shims/xivapi-nodestone.js"),
+    }
+    return config
   },
   images: {
     remotePatterns: [

--- a/src/shims/xivapi-nodestone.js
+++ b/src/shims/xivapi-nodestone.js
@@ -1,0 +1,74 @@
+'use strict'
+
+// CF Workers shim for @xivapi/nodestone.
+// The original package scrapes Lodestone HTML using Node.js (express, cheerio).
+// This shim uses the xivapi.com REST API instead, which works via fetch() in CF Workers.
+
+const XIVAPI = 'https://xivapi.com'
+
+class CharacterSearch {
+  async parse(req) {
+    const { name, server, dc } = req.query ?? {}
+    let url = `${XIVAPI}/character/search?name=${encodeURIComponent(name ?? '')}`
+    if (server) url += `&server=${encodeURIComponent(server)}`
+    else if (dc) url += `&server=_dc_${encodeURIComponent(dc)}`
+    const res = await fetch(url)
+    if (!res.ok) throw new Error(`xivapi search failed: ${res.status}`)
+    const data = await res.json()
+    return {
+      List: (data.Results ?? []).map((r) => ({
+        ID: r.ID,
+        Name: r.Name,
+        World: r.Server,
+        DC: r.DC ?? '',
+        Avatar: r.Avatar ?? '',
+      })),
+    }
+  }
+}
+
+class Character {
+  async parse(req) {
+    const id = req.params?.characterId
+    if (!id) throw new Error('characterId required')
+    const res = await fetch(`${XIVAPI}/character/${id}?extended=1`)
+    if (!res.ok) throw new Error(`xivapi character failed: ${res.status}`)
+    const data = await res.json()
+    const c = data.Character ?? {}
+    return {
+      Name: c.Name,
+      World: c.World,
+      DC: c.DC,
+      Avatar: c.Avatar,
+      Bio: c.Bio,
+      FreeCompany: c.FreeCompanyId ? { ID: c.FreeCompanyId } : undefined,
+    }
+  }
+}
+
+class FCMembers {
+  async parse(req) {
+    const id = req.params?.fcId
+    if (!id) throw new Error('fcId required')
+    const res = await fetch(`${XIVAPI}/freecompany/${id}/members`)
+    if (!res.ok) throw new Error(`xivapi fc members failed: ${res.status}`)
+    const data = await res.json()
+    return { List: (data.FreeCompanyMembers ?? []).map((m) => ({ ID: m.ID })) }
+  }
+}
+
+class FreeCompany {
+  async parse(req) {
+    const id = req.params?.fcId
+    if (!id) throw new Error('fcId required')
+    const res = await fetch(`${XIVAPI}/freecompany/${id}`)
+    if (!res.ok) throw new Error(`xivapi fc failed: ${res.status}`)
+    const data = await res.json()
+    return { Name: data.FreeCompany?.Name }
+  }
+}
+
+exports.CharacterSearch = CharacterSearch
+exports.Character = Character
+exports.FCMembers = FCMembers
+exports.FreeCompany = FreeCompany


### PR DESCRIPTION
## Summary

- `@xivapi/nodestone` has no compiled output, uses Node.js APIs incompatible with CF Workers
- Created `src/shims/xivapi-nodestone.js` implementing all 4 classes via `fetch()` against xivapi.com REST API
- Aliased via `turbopack.resolveAlias` (dev) and webpack `config.resolve.alias` (OpenNext production)

## Test plan

- [ ] `pnpm tsc --noEmit` passes
- [ ] Turbopack build succeeds (no `Module not found: @xivapi/nodestone`)
- [ ] Lodestone character search / verification flow works in CF Workers preview

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)