### PR TITLE
fix: call router.refresh() after admin settings toggle to bust CF route cache

### DIFF
--- a/src/app/admin/settings/lodestone-maintenance-toggle.tsx
+++ b/src/app/admin/settings/lodestone-maintenance-toggle.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import { Label } from "@/components/ui/label"
 
@@ -9,6 +10,7 @@ interface Props {
 }
 
 export function LodestoneMaintenanceToggle({ initialValue }: Props) {
+  const router = useRouter()
   const [enabled, setEnabled] = useState(initialValue)
   const [loading, setLoading] = useState(false)
 
@@ -24,6 +26,7 @@ export function LodestoneMaintenanceToggle({ initialValue }: Props) {
       })
       if (!res.ok) throw new Error("Failed to update")
       toast.success(value ? "Lodestone maintenance mode enabled" : "Lodestone maintenance mode disabled")
+      router.refresh()
     } catch {
       setEnabled(prev) // revert
       toast.error("Failed to update Lodestone maintenance mode")

--- a/src/app/admin/settings/maintenance-toggle.tsx
+++ b/src/app/admin/settings/maintenance-toggle.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import { Label } from "@/components/ui/label"
 
@@ -9,6 +10,7 @@ interface Props {
 }
 
 export function MaintenanceToggle({ initialValue }: Props) {
+  const router = useRouter()
   const [enabled, setEnabled] = useState(initialValue)
   const [loading, setLoading] = useState(false)
 
@@ -24,6 +26,7 @@ export function MaintenanceToggle({ initialValue }: Props) {
       })
       if (!res.ok) throw new Error("Failed to update")
       toast.success(value ? "Maintenance mode enabled" : "Maintenance mode disabled")
+      router.refresh()
     } catch {
       setEnabled(prev) // revert
       toast.error("Failed to update maintenance mode")


### PR DESCRIPTION
## Summary

- Admin settings toggles (`MaintenanceToggle`, `LodestoneMaintenanceToggle`) now call `router.refresh()` after a successful PATCH
- Without this, CF Workers serves stale server-rendered HTML from the route cache — the toggle appears stuck on the old value and the site-wide Lodestone maintenance banner persists after being disabled

## Test plan

- [ ] Toggle Lodestone maintenance mode ON → OFF in `/admin/settings` — banner should disappear immediately
- [ ] Navigate away and back to `/admin/settings` — toggle should show correct state
- [ ] Same test for site maintenance mode toggle

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)