### PR TITLE
fix: bust CF Workers cache and add live banner updates on maintenance toggle

### DIFF
--- a/src/app/admin/settings/lodestone-maintenance-toggle.tsx
+++ b/src/app/admin/settings/lodestone-maintenance-toggle.tsx
@@ -26,6 +26,7 @@ export function LodestoneMaintenanceToggle({ initialValue }: Props) {
       })
       if (!res.ok) throw new Error("Failed to update")
       toast.success(value ? "Lodestone maintenance mode enabled" : "Lodestone maintenance mode disabled")
+      window.dispatchEvent(new CustomEvent("lodestone-maintenance-change", { detail: { active: value } }))
       router.refresh()
     } catch {
       setEnabled(prev) // revert

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic"
+
 import { auth } from "@/lib/auth"
 import { headers } from "next/headers"
 import { redirect } from "next/navigation"

--- a/src/app/api/admin/settings/route.ts
+++ b/src/app/api/admin/settings/route.ts
@@ -2,6 +2,7 @@ import { auth } from "@/lib/auth"
 import { headers } from "next/headers"
 import prisma from "@/lib/prisma"
 import { NextResponse } from "next/server"
+import { revalidatePath } from "next/cache"
 import { z } from "zod"
 
 const schema = z.union([
@@ -29,6 +30,9 @@ export async function PATCH(req: Request) {
     update: data,
     create: { id: "singleton", ...data },
   })
+
+  revalidatePath("/admin/settings")
+  revalidatePath("/", "layout")
 
   const res = NextResponse.json(settings)
   if ("maintenanceMode" in data) {

--- a/src/components/lodestone-maintenance-banner-client.tsx
+++ b/src/components/lodestone-maintenance-banner-client.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { format } from "date-fns"
+
+function formatUtc(date: Date): string {
+  return format(date, "MMM d 'at' h:mm a") + " UTC"
+}
+
+interface Props {
+  initialVisible: boolean
+  initialIsActive: boolean
+  endsAt: string | null
+  startsAt: string | null
+}
+
+export function LodestoneMaintenanceBannerClient({ initialVisible, initialIsActive, endsAt, startsAt }: Props) {
+  const [visible, setVisible] = useState(initialVisible)
+  const [isActive, setIsActive] = useState(initialIsActive)
+
+  useEffect(() => {
+    function handler(e: Event) {
+      const { active } = (e as CustomEvent<{ active: boolean }>).detail
+      // keep visible if there's a scheduled window regardless of manual override
+      setVisible(active || !!startsAt)
+      setIsActive(active || (!!startsAt && new Date(startsAt) <= new Date()))
+    }
+    window.addEventListener("lodestone-maintenance-change", handler)
+    return () => window.removeEventListener("lodestone-maintenance-change", handler)
+  }, [startsAt])
+
+  if (!visible) return null
+
+  return (
+    <div className="bg-yellow-500/10 border-b border-yellow-500/30 px-4 py-2.5 text-sm text-yellow-700 dark:text-yellow-400">
+      <div className="container mx-auto max-w-7xl flex items-center justify-center gap-2">
+        <span className="shrink-0">⚠</span>
+        <span>
+          {isActive ? (
+            <>
+              <strong>Lodestone maintenance in progress</strong> — character verification is temporarily unavailable.
+              {endsAt && <> Expected to end {formatUtc(new Date(endsAt))}.</>}
+            </>
+          ) : (
+            startsAt && endsAt && (
+              <>
+                <strong>Scheduled Lodestone maintenance</strong> — character verification will be unavailable
+                from {formatUtc(new Date(startsAt))} to {formatUtc(new Date(endsAt))}.
+              </>
+            )
+          )}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/lodestone-maintenance-banner.tsx
+++ b/src/components/lodestone-maintenance-banner.tsx
@@ -1,18 +1,14 @@
 import prisma from "@/lib/prisma"
-import { format } from "date-fns"
-
-function formatUtc(date: Date): string {
-  return format(date, "MMM d 'at' h:mm a") + " UTC"
-}
+import { LodestoneMaintenanceBannerClient } from "./lodestone-maintenance-banner-client"
 
 export async function LodestoneMaintenanceBanner() {
   const now = new Date()
   const in24h = new Date(now.getTime() + 24 * 60 * 60 * 1000)
 
-  let window: { title: string; startsAt: Date; endsAt: Date } | null = null
+  let win: { title: string; startsAt: Date; endsAt: Date } | null = null
   let manualOverride = false
   try {
-    const [win, settings] = await Promise.all([
+    const [window, settings] = await Promise.all([
       prisma.lodestoneMaintenanceWindow.findFirst({
         where: { startsAt: { lte: in24h }, endsAt: { gte: now } },
         orderBy: { startsAt: "asc" },
@@ -20,36 +16,21 @@ export async function LodestoneMaintenanceBanner() {
       }),
       prisma.siteSettings.findUnique({ where: { id: "singleton" }, select: { lodestoneMaintenanceMode: true } }),
     ])
-    window = win
+    win = window
     manualOverride = settings?.lodestoneMaintenanceMode ?? false
   } catch {
     return null
   }
 
-  if (!window && !manualOverride) return null
-
-  const isActive = manualOverride || (window !== null && window.startsAt <= now)
+  const visible = !!win || manualOverride
+  const isActive = manualOverride || (win !== null && win.startsAt <= now)
 
   return (
-    <div className="bg-yellow-500/10 border-b border-yellow-500/30 px-4 py-2.5 text-sm text-yellow-700 dark:text-yellow-400">
-      <div className="container mx-auto max-w-7xl flex items-center justify-center gap-2">
-        <span className="shrink-0">⚠</span>
-        <span>
-          {isActive ? (
-            <>
-              <strong>Lodestone maintenance in progress</strong> — character verification is temporarily unavailable.
-              {window && <> Expected to end {formatUtc(window.endsAt)}.</>}
-            </>
-          ) : (
-            window && (
-              <>
-                <strong>Scheduled Lodestone maintenance</strong> — character verification will be unavailable
-                from {formatUtc(window.startsAt)} to {formatUtc(window.endsAt)}.
-              </>
-            )
-          )}
-        </span>
-      </div>
-    </div>
+    <LodestoneMaintenanceBannerClient
+      initialVisible={visible}
+      initialIsActive={isActive}
+      endsAt={win?.endsAt?.toISOString() ?? null}
+      startsAt={win?.startsAt?.toISOString() ?? null}
+    />
   )
 }


### PR DESCRIPTION
## Summary

- `revalidatePath("/admin/settings")` and `revalidatePath("/", "layout")` called in the settings PATCH API route so CF Workers server-side route cache is invalidated on each toggle
- `export const dynamic = "force-dynamic"` added to `/admin/settings` page to prevent opennextjs from ever caching it
- Lodestone maintenance banner split into server component (initial state from DB) + client component (`LodestoneMaintenanceBannerClient`) that listens for a `lodestone-maintenance-change` CustomEvent — banner shows/hides instantly when toggled without waiting for a server re-render
- Toggle dispatches the CustomEvent on successful PATCH

## Test plan

- [ ] Toggle Lodestone maintenance mode ON — banner appears immediately on the same page
- [ ] Toggle OFF — banner disappears immediately
- [ ] Navigate away and back — toggle state and banner reflect DB state correctly

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)