### PR TITLE
fix: add check-lodestone-maintenance to CF Workers scheduled handler

### DIFF
--- a/scripts/patch-cf-externals.mjs
+++ b/scripts/patch-cf-externals.mjs
@@ -499,19 +499,25 @@ export { default } from "./worker-original.js"
 export const scheduled = async (event, env, ctx) => {
   const secret = env.CRON_SECRET ?? ""
   const baseUrl = env.BETTER_AUTH_URL ?? "http://localhost:8787"
-  try {
-    const res = await fetch(\`\${baseUrl}/api/cron/verify-fc-estates\`, {
-      headers: { Authorization: \`Bearer \${secret}\` },
-    })
-    if (!res.ok) {
-      console.error("[cron] verify-fc-estates failed:", res.status)
-    } else {
-      const result = await res.json()
-      console.log("[cron] verify-fc-estates result:", JSON.stringify(result))
+
+  const runCron = async (path) => {
+    try {
+      const res = await fetch(\`\${baseUrl}\${path}\`, {
+        headers: { Authorization: \`Bearer \${secret}\` },
+      })
+      if (!res.ok) {
+        console.error(\`[cron] \${path} failed:\`, res.status)
+      } else {
+        const result = await res.json()
+        console.log(\`[cron] \${path} result:\`, JSON.stringify(result))
+      }
+    } catch (err) {
+      console.error(\`[cron] \${path} error:\`, err)
     }
-  } catch (err) {
-    console.error("[cron] verify-fc-estates error:", err)
   }
+
+  await runCron("/api/cron/check-lodestone-maintenance")
+  await runCron("/api/cron/verify-fc-estates")
 }
 `.trimStart()
 


### PR DESCRIPTION
## Summary

- Wires `/api/cron/check-lodestone-maintenance` into the CF Workers `scheduled` event handler in `patch-cf-externals.mjs`
- Previously only `verify-fc-estates` was called — the Lodestone maintenance cron never auto-fired in production
- Both crons now run sequentially on each scheduled trigger

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)