### PR TITLE
feat: show Eastern Time alongside UTC in admin maintenance windows

### DIFF
--- a/src/app/admin/settings/maintenance-windows.tsx
+++ b/src/app/admin/settings/maintenance-windows.tsx
@@ -5,6 +5,22 @@ function formatUtc(date: Date): string {
   return format(date, "MMM d, yyyy h:mm a") + " UTC"
 }
 
+function formatEt(date: Date): string {
+  return date.toLocaleString("en-US", {
+    timeZone: "America/New_York",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  })
+}
+
+function formatWindow(date: Date): string {
+  return `${formatUtc(date)} / ${formatEt(date)}`
+}
+
 function WindowRow({
   window,
   now,
@@ -39,7 +55,7 @@ function WindowRow({
           </a>
         </div>
         <p className="text-muted-foreground">
-          {formatUtc(window.startsAt)} &rarr; {formatUtc(window.endsAt)}
+          {formatWindow(window.startsAt)} &rarr; {formatWindow(window.endsAt)}
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Admin dashboard maintenance windows now show ET alongside UTC for each time
- Format: `May 7, 2026 6:00 AM UTC / May 7, 2026 2:00 AM EDT`
- Handles EDT/EST automatically via `America/New_York` timezone

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)