### PR TITLE
fix: use explicit UTC timezone in maintenance banner time formatting

### DIFF
--- a/src/components/lodestone-maintenance-banner-client.tsx
+++ b/src/components/lodestone-maintenance-banner-client.tsx
@@ -1,10 +1,15 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { format } from "date-fns"
 
 function formatUtc(date: Date): string {
-  return format(date, "MMM d 'at' h:mm a") + " UTC"
+  return date.toLocaleString("en-US", {
+    timeZone: "UTC",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }) + " UTC"
 }
 
 interface Props {


### PR DESCRIPTION
## Summary

- `date-fns` `format()` runs in browser local timezone — times were displaying in user's local time but labeled "UTC"
- Replaced with `toLocaleString` using `timeZone: "UTC"` so times are always correct regardless of user locale

## Test plan

- [ ] View maintenance banner in a browser set to a non-UTC timezone — times should match actual UTC

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)