### PR TITLE
fix: disable verify form when active maintenance window exists in DB

### DIFF
--- a/src/app/dashboard/verify/page.tsx
+++ b/src/app/dashboard/verify/page.tsx
@@ -11,7 +11,8 @@ export default async function VerifyPage() {
   const session = await auth.api.getSession({ headers: await headers() })
   if (!session?.user?.id) redirect("/login")
 
-  const [pending, settings] = await prisma.$transaction([
+  const now = new Date()
+  const [pending, settings, activeWindow] = await prisma.$transaction([
     prisma.lodestoneVerification.findFirst({
       where: {
         verified: false,
@@ -20,10 +21,13 @@ export default async function VerifyPage() {
       include: { character: true },
     }),
     prisma.siteSettings.findUnique({ where: { id: "singleton" } }),
+    prisma.lodestoneMaintenanceWindow.findFirst({
+      where: { startsAt: { lte: now }, endsAt: { gte: now } },
+    }),
   ])
 
   const isExpired = pending ? pending.expiresAt <= new Date() : false
-  const lodestoneMaintenance = settings?.lodestoneMaintenanceMode ?? false
+  const lodestoneMaintenance = (settings?.lodestoneMaintenanceMode ?? false) || !!activeWindow
 
   return (
     <div className="container mx-auto max-w-xl px-4 py-10">


### PR DESCRIPTION
## Summary

Verify page only checked `SiteSettings.lodestoneMaintenanceMode` flag. If cron inserted an active `LodestoneMaintenanceWindow` but the flag wasn't set (race, manual insert, or any gap), the form stayed enabled.

Now queries both — form is disabled if either the flag is true **or** an active window exists in the DB.

## Test plan

- [ ] Insert active maintenance window directly in DB with flag `false` — verify form shows disabled state
- [ ] With neither flag nor window, form is enabled

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)