### PR TITLE
release: disable verify form when active maintenance window exists

### DIFF
--- a/src/app/dashboard/verify/page.tsx
+++ b/src/app/dashboard/verify/page.tsx
@@ -11,7 +11,8 @@ export default async function VerifyPage() {
   const session = await auth.api.getSession({ headers: await headers() })
   if (!session?.user?.id) redirect("/login")
 
-  const [pending, settings] = await prisma.$transaction([
+  const now = new Date()
+  const [pending, settings, activeWindow] = await prisma.$transaction([
     prisma.lodestoneVerification.findFirst({
       where: {
         verified: false,
@@ -20,10 +21,13 @@ export default async function VerifyPage() {
       include: { character: true },
     }),
     prisma.siteSettings.findUnique({ where: { id: "singleton" } }),
+    prisma.lodestoneMaintenanceWindow.findFirst({
+      where: { startsAt: { lte: now }, endsAt: { gte: now } },
+    }),
   ])
 
   const isExpired = pending ? pending.expiresAt <= new Date() : false
-  const lodestoneMaintenance = settings?.lodestoneMaintenanceMode ?? false
+  const lodestoneMaintenance = (settings?.lodestoneMaintenanceMode ?? false) || !!activeWindow
 
   return (
     <div className="container mx-auto max-w-xl px-4 py-10">


### PR DESCRIPTION
## Summary

- Verify page form now disabled when an active `LodestoneMaintenanceWindow` record exists in DB, not just when the manual `lodestoneMaintenanceMode` flag is set (#362)

## Test plan

- [ ] Confirm verify page inputs disabled during an active maintenance window

🤖 Generated with [Claude Code](https://claude.com/claude-code)