### PR TITLE
fix: bypass BA runWithRequestState in polled CF Workers routes

### DIFF
--- a/src/app/api/notifications/unread/route.ts
+++ b/src/app/api/notifications/unread/route.ts
@@ -1,18 +1,15 @@
-import { auth } from "@/lib/auth"
-import { headers } from "next/headers"
+import { getSessionFromRequest } from "@/lib/session"
 import prisma from "@/lib/prisma"
 import { NextResponse } from "next/server"
 
-export async function GET() {
-  const session = await auth.api.getSession({ headers: await headers() })
-  if (!session?.user?.id) {
+export async function GET(req: Request) {
+  const session = await getSessionFromRequest(req)
+  if (!session) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
   }
 
-  const userId = session.user.id
+  const userId = session.userId
 
-  // Count conversations where the current user's readAt is null
-  // and the last message was sent by the other party
   const conversations = await prisma.conversation.findMany({
     where: {
       OR: [
@@ -30,7 +27,6 @@ export async function GET() {
     },
   })
 
-  // Only count if the last message was not sent by the current user
   const count = conversations.filter((conv) => {
     const lastMsg = conv.messages[0]
     return lastMsg && lastMsg.senderId !== userId

--- a/src/app/api/presence/route.ts
+++ b/src/app/api/presence/route.ts
@@ -1,16 +1,15 @@
-import { auth } from "@/lib/auth"
-import { headers } from "next/headers"
+import { getSessionFromRequest } from "@/lib/session"
 import prisma from "@/lib/prisma"
 import { NextResponse } from "next/server"
 
-export async function POST() {
-  const session = await auth.api.getSession({ headers: await headers() })
-  if (!session?.user?.id) {
+export async function POST(req: Request) {
+  const session = await getSessionFromRequest(req)
+  if (!session) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
   }
 
   await prisma.user.update({
-    where: { id: session.user.id },
+    where: { id: session.userId },
     data: { lastSeenAt: new Date() },
   })
 

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,6 +1,7 @@
 import { cache } from "react"
 import { headers } from "next/headers"
 import { auth } from "@/lib/auth"
+import prisma from "@/lib/prisma"
 
 // React cache() deduplicates this call within a single RSC render tree.
 // Both layout.tsx and navbar.tsx call getServerSession() — only one DB
@@ -12,3 +13,44 @@ export const getServerSession = cache(async () => {
     return null
   }
 })
+
+// Direct Prisma session lookup that bypasses Better Auth's AsyncLocalStorage
+// context requirement. Use in API routes where BA's runWithRequestState fails
+// in CF Workers (e.g. polled endpoints wrapped by Sentry instrumentation).
+//
+// Cookie format: better-auth.session_token = "<token>.<hmac-sha256-base64>"
+export async function getSessionFromRequest(req: Request): Promise<{ userId: string } | null> {
+  const cookieHeader = req.headers.get("cookie") ?? ""
+  const match = cookieHeader.match(/(?:^|;\s*)better-auth\.session_token=([^;]+)/)
+  if (!match) return null
+
+  const signed = decodeURIComponent(match[1])
+  const lastDot = signed.lastIndexOf(".")
+  if (lastDot === -1) return null
+
+  const token = signed.slice(0, lastDot)
+  const signature = signed.slice(lastDot + 1)
+
+  const secret = process.env.BETTER_AUTH_SECRET
+  if (!secret) return null
+
+  // Verify HMAC-SHA256 signature (same algorithm as BA's makeSignature)
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  )
+  const sigBytes = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(token))
+  const expected = btoa(String.fromCharCode(...new Uint8Array(sigBytes)))
+  if (expected !== signature) return null
+
+  const session = await prisma.session.findUnique({
+    where: { token },
+    select: { userId: true, expiresAt: true },
+  })
+  if (!session || !session.expiresAt || session.expiresAt < new Date()) return null
+
+  return { userId: session.userId }
+}


### PR DESCRIPTION
## Summary

`/api/notifications/unread` and `/api/presence` intermittently throw `[better-auth] INTERNAL_SERVER_ERROR Error: No request state found` in CF Workers production. Root cause: Sentry's `autoInstrumentServerFunctions` wraps route handlers with async layers that break BA's `AsyncLocalStorage` context propagation — visible on polled routes every ~5 minutes.

**Changes:**
- `src/lib/session.ts`: Add `getSessionFromRequest(req)` — verifies the `better-auth.session_token` signed cookie using Web Crypto API (HMAC-SHA256), then does a direct Prisma session lookup. Zero BA context dependency.
- `src/app/api/notifications/unread/route.ts`: Switch to `getSessionFromRequest`
- `src/app/api/presence/route.ts`: Switch to `getSessionFromRequest`

## Test plan

- [ ] Deploy to CF preview, poll `/api/notifications/unread` — no `runWithRequestState` errors in logs
- [ ] Authenticated requests return correct data; unauthenticated return 401

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)