### PR TITLE
fix: log active database connection source in Prisma client

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -20,6 +20,11 @@ function createPrismaClient() {
     if (hyperdrive?.connectionString) {
       connectionString = hyperdrive.connectionString
       ssl = false
+      const u = new URL(connectionString)
+      console.log(`[prisma] using Hyperdrive: ${u.host}${u.pathname}`)
+    } else {
+      const u = new URL(connectionString)
+      console.log(`[prisma] using DATABASE_URL: ${u.host}${u.pathname}`)
     }
   } catch {
     // Not in CF Workers context (Next.js dev server, build time, etc.) — use DATABASE_URL


### PR DESCRIPTION
## Summary

Adds `console.log` in `createPrismaClient` showing whether CF Workers production is routing through Hyperdrive or falling back to `DATABASE_URL`. Needed to diagnose the `Transaction not found` error on `/api/auth/register` — changing `DATABASE_URL` had no effect, suggesting Hyperdrive is overriding it.

## What to look for in logs

After deploying, trigger a registration attempt and check CF Workers logs for:
- `[prisma] using Hyperdrive: <host>/<db>` — Hyperdrive is active (need to reconfigure Hyperdrive, not env var)
- `[prisma] using DATABASE_URL: <host>/<db>` — env var is active

Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)