### PR TITLE
release: debug Prisma connection source in CF Workers

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -20,6 +20,11 @@ function createPrismaClient() {
     if (hyperdrive?.connectionString) {
       connectionString = hyperdrive.connectionString
       ssl = false
+      const u = new URL(connectionString)
+      console.log(`[prisma] using Hyperdrive: ${u.host}${u.pathname}`)
+    } else {
+      const u = new URL(connectionString)
+      console.log(`[prisma] using DATABASE_URL: ${u.host}${u.pathname}`)
     }
   } catch {
     // Not in CF Workers context (Next.js dev server, build time, etc.) — use DATABASE_URL


### PR DESCRIPTION
## Summary

- Log whether CF Workers uses Hyperdrive or DATABASE_URL for Prisma connections (#370, closes #369)

Needed to diagnose `Transaction not found` error on `/api/auth/register` — changing `DATABASE_URL` had no effect, indicating Hyperdrive is likely overriding it.

## After deploying

Trigger a registration attempt and check CF Workers logs for `[prisma] using Hyperdrive:` or `[prisma] using DATABASE_URL:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)