### PR TITLE
fix: use BA-compatible scrypt hash in register endpoint

### DIFF
--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 import { z } from "zod"
-import bcrypt from "bcryptjs"
+import { hashPassword } from "better-auth/crypto"
 import prisma from "@/lib/prisma"
 
 const schema = z
@@ -44,7 +44,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "An account with this email already exists" }, { status: 409 })
   }
 
-  const hashed = await bcrypt.hash(password, 12)
+  const hashed = await hashPassword(password)
 
   await prisma.$transaction(async (tx) => {
     await tx.verificationToken.deleteMany({ where: { identifier: email } })


### PR DESCRIPTION
## Summary

- Fix email/password sign-in failing with "Invalid password hash" after registration
- Replace `bcrypt.hash()` with `hashPassword` from `better-auth/crypto` in `/api/auth/register`

## Root Cause

`/api/auth/register` hashed passwords with `bcrypt` (format: `$2b$12$...`). Better Auth's `verifyPassword` expects the `@better-auth/utils` scrypt format (`salt:key` hex). Bcrypt hashes have no `:` separator, so `verifyPassword` threw "Invalid password hash" immediately without even checking the password.

## Test plan

- [ ] Deploy to production
- [ ] Register a new account end-to-end
- [ ] Verify sign-in succeeds after registration

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)