### PR TITLE
release: fix email/password registration hash mismatch

### DIFF
--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 import { z } from "zod"
-import bcrypt from "bcryptjs"
+import { hashPassword } from "better-auth/crypto"
 import prisma from "@/lib/prisma"
 
 const schema = z
@@ -44,7 +44,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "An account with this email already exists" }, { status: 409 })
   }
 
-  const hashed = await bcrypt.hash(password, 12)
+  const hashed = await hashPassword(password)
 
   await prisma.$transaction(async (tx) => {
     await tx.verificationToken.deleteMany({ where: { identifier: email } })


### PR DESCRIPTION
## Summary

- Fix sign-in failing with "Invalid password hash" after email/password registration

## Changes

- `src/app/api/auth/register/route.ts`: Replace `bcrypt.hash()` with `hashPassword` from `better-auth/crypto`. Registration was storing bcrypt hashes but BA's sign-in verifier expects scrypt `salt:key` hex format — no `:` in bcrypt = immediate "Invalid password hash" error.

## Notes

Users who registered during the broken period have bcrypt hashes stored. They will need to use "Forgot password" to reset and set a new (correctly formatted) hash.

## Test plan

- [ ] Deploy to production
- [ ] Register new account end-to-end
- [ ] Verify sign-in succeeds immediately after registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)