### PR TITLE
fix: add BETTER_AUTH_SECRET and BETTER_AUTH_URL to build env in deploy workflows

### DIFF
--- a/.github/workflows/deploy-cf-auto.yml
+++ b/.github/workflows/deploy-cf-auto.yml
@@ -46,6 +46,8 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           DIRECT_URL: ${{ secrets.DIRECT_URL }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+          BETTER_AUTH_URL: ${{ vars.BETTER_AUTH_URL }}
 
       - name: Deploy
         run: pnpm exec wrangler deploy --env production

--- a/.github/workflows/deploy-cf-preview.yml
+++ b/.github/workflows/deploy-cf-preview.yml
@@ -48,6 +48,8 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           DIRECT_URL: ${{ secrets.DIRECT_URL }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+          BETTER_AUTH_URL: ${{ vars.BETTER_AUTH_URL }}
 
       - name: Deploy
         run: pnpm exec wrangler deploy --env preview


### PR DESCRIPTION
## Summary

- Pass `BETTER_AUTH_SECRET` and `BETTER_AUTH_URL` to the build step in both `deploy-cf-auto.yml` and `deploy-cf-preview.yml`

## Root Cause

BA calls `betterAuth()` at module import time. During `next build`, it logs:
```
Base URL could not be determined...
Error: [BetterAuthError]: You are using the default secret...
```
These env vars were set as CF runtime secrets but not passed to the GitHub Actions build step.

`BETTER_AUTH_SECRET` → existing GitHub secret  
`BETTER_AUTH_URL` → existing GitHub variable (`vars.BETTER_AUTH_URL`)

## Test plan

- [ ] Next deploy build has no BA startup warnings

Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)