### PR TITLE
release: fix BA build warnings — add auth env vars to deploy workflows

### DIFF
--- a/.github/workflows/deploy-cf-auto.yml
+++ b/.github/workflows/deploy-cf-auto.yml
@@ -46,6 +46,8 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           DIRECT_URL: ${{ secrets.DIRECT_URL }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+          BETTER_AUTH_URL: ${{ vars.BETTER_AUTH_URL }}
 
       - name: Deploy
         run: pnpm exec wrangler deploy --env production

--- a/.github/workflows/deploy-cf-preview.yml
+++ b/.github/workflows/deploy-cf-preview.yml
@@ -48,6 +48,8 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           DIRECT_URL: ${{ secrets.DIRECT_URL }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+          BETTER_AUTH_URL: ${{ vars.BETTER_AUTH_URL }}
 
       - name: Deploy
         run: pnpm exec wrangler deploy --env preview


### PR DESCRIPTION
## Summary

- Pass `BETTER_AUTH_SECRET` and `BETTER_AUTH_URL` to the build step in both deploy workflows to silence BA startup warnings during `next build`

## Changes

- `.github/workflows/deploy-cf-auto.yml`: add `BETTER_AUTH_SECRET` + `BETTER_AUTH_URL` to build env
- `.github/workflows/deploy-cf-preview.yml`: same

## Test plan

- [ ] Next deploy build has no BA startup warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)