### PR TITLE
fix: add OAuth env vars to build step in deploy workflows

### DIFF
--- a/.github/workflows/deploy-cf-auto.yml
+++ b/.github/workflows/deploy-cf-auto.yml
@@ -48,6 +48,10 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
           BETTER_AUTH_URL: ${{ vars.BETTER_AUTH_URL }}
+          AUTH_DISCORD_ID: ${{ secrets.AUTH_DISCORD_ID }}
+          AUTH_DISCORD_SECRET: ${{ secrets.AUTH_DISCORD_SECRET }}
+          AUTH_GOOGLE_ID: ${{ secrets.AUTH_GOOGLE_ID }}
+          AUTH_GOOGLE_SECRET: ${{ secrets.AUTH_GOOGLE_SECRET }}
 
       - name: Deploy
         run: pnpm exec wrangler deploy --env production

--- a/.github/workflows/deploy-cf-preview.yml
+++ b/.github/workflows/deploy-cf-preview.yml
@@ -50,6 +50,10 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
           BETTER_AUTH_URL: ${{ vars.BETTER_AUTH_URL }}
+          AUTH_DISCORD_ID: ${{ secrets.AUTH_DISCORD_ID }}
+          AUTH_DISCORD_SECRET: ${{ secrets.AUTH_DISCORD_SECRET }}
+          AUTH_GOOGLE_ID: ${{ secrets.AUTH_GOOGLE_ID }}
+          AUTH_GOOGLE_SECRET: ${{ secrets.AUTH_GOOGLE_SECRET }}
 
       - name: Deploy
         run: pnpm exec wrangler deploy --env preview


### PR DESCRIPTION
## Summary

- Add Discord and Google OAuth env vars to the build step in both deploy workflows

## Root Cause

BA logs warnings during `next build` when OAuth provider credentials are missing. These were set as CF runtime secrets but not in the build environment.

## Test plan

- [ ] Next deploy build has no BA OAuth provider warnings

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)