### PR TITLE
fix: use providerId and filter credentials in admin users provider column

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -29,7 +29,7 @@ export default async function AdminUsersPage() {
       createdAt: true,
       _count: { select: { estates: true, characters: true } },
       characters: { where: { verified: true }, select: { id: true, characterName: true, avatarUrl: true, lodestoneId: true }, orderBy: { createdAt: "asc" } },
-      accounts: { select: { provider: true } },
+      accounts: { select: { provider: true, providerId: true } },
     },
     orderBy: { createdAt: "asc" },
   })
@@ -83,9 +83,12 @@ export default async function AdminUsersPage() {
                   </div>
                 </td>
                 <td className="px-4 py-3 text-muted-foreground text-xs">
-                  {user.accounts.length > 0
-                    ? user.accounts.map((a) => a.provider).join(", ")
-                    : user.email ? "email" : "—"}
+                  {(() => {
+                    const providers = user.accounts
+                      .map((a) => a.providerId ?? a.provider)
+                      .filter((p): p is string => !!p && p !== "credential" && p !== "credentials")
+                    return providers.length > 0 ? providers.join(", ") : user.email ? "email" : "—"
+                  })()}
                 </td>
                 <td className="px-4 py-3">
                   {user.characters.length > 0 ? (


### PR DESCRIPTION
## Summary

- Fix admin users page showing `credentials,` instead of OAuth provider names

## Root Cause

The auth column read `a.provider` (legacy NextAuth field, set to `"credentials"` by our register route) instead of `a.providerId` (BA field: `"google"`, `"discord"`). Credential accounts weren't filtered out.

## Fix

- Select both `provider` and `providerId` from accounts
- Use `a.providerId ?? a.provider` with filter for `"credential"`/`"credentials"`
- Fall back to `"email"` when no OAuth providers found

## Test plan

- [ ] Admin users page shows `email` for email/password users, `discord`/`google` for OAuth users

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)