### PR TITLE
fix: remove extra leading comma in scheduled handler injection

### DIFF
--- a/scripts/patch-cf-externals.mjs
+++ b/scripts/patch-cf-externals.mjs
@@ -496,7 +496,7 @@ if (workerSrc.includes("async scheduled(")) {
   if (closeIdx === -1 || closeIdx < workerSrc.length - CLOSE.length - 5) {
     console.error("[patch-cf-externals] Could not find default export closing }; in worker.js — skipping scheduled patch.")
   } else {
-    const scheduledMethod = `,
+    const scheduledMethod = `
     async scheduled(event, env, ctx) {
         const secret = env.CRON_SECRET ?? ""
         const baseUrl = env.BETTER_AUTH_URL ?? "http://localhost:8787"


### PR DESCRIPTION
## Summary

- Fix wrangler build error: `Expected identifier but found ","` at `.open-next/worker.js:42:6`

## Root Cause

The `fetch` method in the opennextjs `worker.js` template ends with `},` (trailing comma already present for the object literal). The injected `scheduledMethod` string started with `,\n    async scheduled(`, producing `},,` — a syntax error.

## Fix

Remove the leading `,` from `scheduledMethod`. The fetch method's existing trailing comma already separates the two methods.

## Test plan

- [ ] Deploy succeeds (no wrangler build error)
- [ ] Cron fires at next hour mark with `[cron] result:` logs

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)