### PR TITLE
release: fix scheduled handler double-comma syntax error in worker.js

### DIFF
--- a/scripts/patch-cf-externals.mjs
+++ b/scripts/patch-cf-externals.mjs
@@ -496,7 +496,7 @@ if (workerSrc.includes("async scheduled(")) {
   if (closeIdx === -1 || closeIdx < workerSrc.length - CLOSE.length - 5) {
     console.error("[patch-cf-externals] Could not find default export closing }; in worker.js — skipping scheduled patch.")
   } else {
-    const scheduledMethod = `,
+    const scheduledMethod = `
     async scheduled(event, env, ctx) {
         const secret = env.CRON_SECRET ?? ""
         const baseUrl = env.BETTER_AUTH_URL ?? "http://localhost:8787"


### PR DESCRIPTION
## Summary

- Fix wrangler deploy failing with `Expected identifier but found ","` at worker.js:42

## Changes

- `scripts/patch-cf-externals.mjs`: remove leading `,` from scheduled method injection — the fetch method already has a trailing comma

## Test plan

- [ ] Deploy succeeds
- [ ] Cron fires at next hour with `[cron] result:` in CF Workers logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)