### PR TITLE
fix: show Eastern time in lodestone maintenance banner

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+allowBuilds:
+  '@prisma/engines': true
+  '@sentry/cli': true
+  esbuild: true
+  msw: true
+  prisma: true
+  protobufjs: true
+  sharp: true
+  unrs-resolver: true
+  workerd: true

--- a/src/components/lodestone-maintenance-banner-client.tsx
+++ b/src/components/lodestone-maintenance-banner-client.tsx
@@ -2,14 +2,15 @@
 
 import { useEffect, useState } from "react"
 
-function formatUtc(date: Date): string {
+function formatEastern(date: Date): string {
   return date.toLocaleString("en-US", {
-    timeZone: "UTC",
+    timeZone: "America/New_York",
     month: "short",
     day: "numeric",
     hour: "numeric",
     minute: "2-digit",
-  }) + " UTC"
+    timeZoneName: "short",
+  })
 }
 
 interface Props {
@@ -44,13 +45,13 @@ export function LodestoneMaintenanceBannerClient({ initialVisible, initialIsActi
           {isActive ? (
             <>
               <strong>Lodestone maintenance in progress</strong> — character verification is temporarily unavailable.
-              {endsAt && <> Expected to end {formatUtc(new Date(endsAt))}.</>}
+              {endsAt && <> Expected to end {formatEastern(new Date(endsAt))}.</>}
             </>
           ) : (
             startsAt && endsAt && (
               <>
                 <strong>Scheduled Lodestone maintenance</strong> — character verification will be unavailable
-                from {formatUtc(new Date(startsAt))} to {formatUtc(new Date(endsAt))}.
+                from {formatEastern(new Date(startsAt))} to {formatEastern(new Date(endsAt))}.
               </>
             )
           )}


### PR DESCRIPTION
## Summary

- Maintenance banner was displaying times in UTC (e.g. "10:00 AM UTC")
- Now displays Eastern time with timezone abbreviation (e.g. "6:00 AM EDT") to match what players see on Lodestone maintenance notices
- Also adds `pnpm-workspace.yaml` with `allowBuilds` set to `true` (missing from `main`, causing pre-commit hook failures with pnpm v11)

Closes #442